### PR TITLE
GH-20 feature/threading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /jdm.properties
 /tmp
 *.zip
+*.patch
 /build.properties
 /derbyDB/

--- a/build.xml
+++ b/build.xml
@@ -73,7 +73,7 @@
     -->
     
     <!-- software revision number -->
-    <property name="version" value="0.6.0-dev.e"/>
+    <property name="version" value="0.6.0-dev.f.threading"/>
     <property name="releaseDir" value="jdiskmark-${version}"/>
     
     <target name="-post-jar">

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -67,6 +67,7 @@ public class App {
     public static int numOfSamples = 200;   // desired number of samples
     public static int numOfBlocks = 32;     // desired number of blocks
     public static int blockSizeKb = 512;    // size of a block in KBs
+    public static int numOfThreads = 1;     // number of threads
     
     public static BenchmarkWorker worker = null;
     public static int nextSampleNumber = 1;   // number of the next sample
@@ -220,6 +221,8 @@ public class App {
         numOfBlocks = Integer.parseInt(value);
         value = p.getProperty("blockSizeKb", String.valueOf(blockSizeKb));
         blockSizeKb = Integer.parseInt(value);
+        value = p.getProperty("numOfThreads", String.valueOf(numOfThreads));
+        numOfThreads = Integer.parseInt(value);
         value = p.getProperty("writeTest", String.valueOf(writeTest));
         writeTest = Boolean.parseBoolean(value);
         value = p.getProperty("readTest", String.valueOf(readTest));
@@ -243,6 +246,7 @@ public class App {
         p.setProperty("numOfSamples", String.valueOf(numOfSamples));
         p.setProperty("numOfBlocks", String.valueOf(numOfBlocks));
         p.setProperty("blockSizeKb", String.valueOf(blockSizeKb));
+        p.setProperty("numOfThreads", String.valueOf(numOfThreads));
         p.setProperty("writeTest", String.valueOf(writeTest));
         p.setProperty("readTest", String.valueOf(readTest));
         p.setProperty("writeSyncEnable", String.valueOf(writeSyncEnable));
@@ -271,6 +275,7 @@ public class App {
         sb.append("numOfFiles: ").append(numOfSamples).append('\n');
         sb.append("numOfBlocks: ").append(numOfBlocks).append('\n');
         sb.append("blockSizeKb: ").append(blockSizeKb).append('\n');
+        sb.append("numOfThreads: ").append(numOfThreads).append('\n');
         sb.append("palette: ").append(Gui.palette).append('\n');
         return sb.toString();
     }
@@ -351,13 +356,13 @@ public class App {
         worker.addPropertyChangeListener((final var event) -> {
             switch (event.getPropertyName()) {
                 case "progress" -> {
-                    int value = (Integer) event.getNewValue();
+                    int value = (Integer)event.getNewValue();
                     Gui.progressBar.setValue(value);
-                    long kbProcessed = (value) * App.targetTxSizeKb() / 100;
+                    long kbProcessed = value * App.targetTxSizeKb() / 100;
                     Gui.progressBar.setString(String.valueOf(kbProcessed) + " / " + String.valueOf(App.targetTxSizeKb()));
                 }
                 case "state" -> {
-                    switch ((StateValue) event.getNewValue()) {
+                    switch ((StateValue)event.getNewValue()) {
                         case STARTED -> Gui.progressBar.setString("0 / " + String.valueOf(App.targetTxSizeKb()));
                         case DONE -> {}
                     } // end inner switch

--- a/src/jdiskmark/Benchmark.java
+++ b/src/jdiskmark/Benchmark.java
@@ -63,7 +63,7 @@ public class Benchmark implements Serializable {
     @Column
     double totalGb;
     
-    // configuration
+    // benchmark parameters
     @Column
     IOMode ioMode;
     @Column
@@ -76,6 +76,8 @@ public class Benchmark implements Serializable {
     int numSamples = 0;
     @Column
     long txSize = 0;
+    @Column
+    int numThreads = 1;
     
     // timestamps
     @Convert(converter = LocalDateTimeAttributeConverter.class)
@@ -135,7 +137,8 @@ public class Benchmark implements Serializable {
         return percentUsed + "%";
     }
     
-    public void add(Sample s) {
+    // GH-20 TODO: review should this be synchronized or redone to not be blocking?
+    public synchronized void add(Sample s) {
         samples.add(s);
     }
     

--- a/src/jdiskmark/Benchmark.java
+++ b/src/jdiskmark/Benchmark.java
@@ -144,6 +144,10 @@ public class Benchmark implements Serializable {
     
     // display friendly methods
     
+    public String getBlocksDisplay() {
+        return numBlocks + " (" + blockSize + ")";
+    }
+    
     public String getStartTimeString() {
         return startTime.format(DATE_FORMAT);
     }
@@ -158,6 +162,10 @@ public class Benchmark implements Serializable {
     
     public String getBwMaxDisplay() {
         return bwMax == -1 ? "- -" : DF.format(bwMax);
+    }
+    
+    public String getBwMinMaxDisplay() {
+        return bwMax == -1 ? "- -" : DFT.format(bwMin) + "/" + DFT.format(bwMax);
     }
     
     public String getBwAvgDisplay() {

--- a/src/jdiskmark/BenchmarkPanel.form
+++ b/src/jdiskmark/BenchmarkPanel.form
@@ -44,21 +44,20 @@
         <Component class="javax.swing.JTable" name="runTable">
           <Properties>
             <Property name="model" type="javax.swing.table.TableModel" editor="org.netbeans.modules.form.editors2.TableModelEditor">
-              <Table columnCount="14" rowCount="0">
+              <Table columnCount="13" rowCount="0">
                 <Column editable="false" title="ID" type="java.lang.Object"/>
                 <Column editable="false" title="Drive Model" type="java.lang.Object"/>
                 <Column editable="false" title="Usage" type="java.lang.Object"/>
                 <Column editable="false" title="Mode" type="java.lang.Object"/>
                 <Column editable="false" title="Order" type="java.lang.Object"/>
                 <Column editable="false" title="Samples" type="java.lang.Object"/>
-                <Column editable="false" title="Blks" type="java.lang.Object"/>
-                <Column editable="false" title="B.Size" type="java.lang.Object"/>
+                <Column editable="false" title="Blocks (Size)" type="java.lang.Object"/>
+                <Column editable="false" title="Thread" type="java.lang.Object"/>
                 <Column editable="false" title="Start Time" type="java.lang.Object"/>
-                <Column editable="false" title="Duration (ms)" type="java.lang.Object"/>
-                <Column editable="false" title="Access (ms)" type="java.lang.Object"/>
-                <Column editable="false" title="Max (MB/s)" type="java.lang.Object"/>
-                <Column editable="false" title="Min (MB/s)" type="java.lang.Object"/>
-                <Column editable="false" title="Avg (MB/s)" type="java.lang.Object"/>
+                <Column editable="false" title="Time (ms)" type="java.lang.Object"/>
+                <Column editable="false" title="Acc (ms)" type="java.lang.Object"/>
+                <Column editable="false" title="Min/Max (MB/s)" type="java.lang.Object"/>
+                <Column editable="false" title="IO (MB/s)" type="java.lang.Object"/>
               </Table>
             </Property>
             <Property name="columnModel" type="javax.swing.table.TableColumnModel" editor="org.netbeans.modules.form.editors2.TableColumnModelEditor">
@@ -68,17 +67,17 @@
                   <Editor/>
                   <Renderer/>
                 </Column>
-                <Column maxWidth="-1" minWidth="-1" prefWidth="170" resizable="true">
+                <Column maxWidth="-1" minWidth="-1" prefWidth="135" resizable="true">
                   <Title/>
                   <Editor/>
                   <Renderer/>
                 </Column>
-                <Column maxWidth="-1" minWidth="-1" prefWidth="10" resizable="true">
+                <Column maxWidth="45" minWidth="-1" prefWidth="46" resizable="true">
                   <Title/>
                   <Editor/>
                   <Renderer/>
                 </Column>
-                <Column maxWidth="-1" minWidth="-1" prefWidth="10" resizable="true">
+                <Column maxWidth="-1" minWidth="-1" prefWidth="6" resizable="true">
                   <Title/>
                   <Editor/>
                   <Renderer/>
@@ -93,22 +92,22 @@
                   <Editor/>
                   <Renderer/>
                 </Column>
-                <Column maxWidth="-1" minWidth="-1" prefWidth="5" resizable="true">
+                <Column maxWidth="-1" minWidth="-1" prefWidth="35" resizable="true">
                   <Title/>
                   <Editor/>
                   <Renderer/>
                 </Column>
-                <Column maxWidth="-1" minWidth="-1" prefWidth="6" resizable="true">
+                <Column maxWidth="45" minWidth="-1" prefWidth="45" resizable="true">
                   <Title/>
                   <Editor/>
                   <Renderer/>
                 </Column>
-                <Column maxWidth="-1" minWidth="-1" prefWidth="90" resizable="true">
+                <Column maxWidth="-1" minWidth="-1" prefWidth="80" resizable="true">
                   <Title/>
                   <Editor/>
                   <Renderer/>
                 </Column>
-                <Column maxWidth="-1" minWidth="-1" prefWidth="6" resizable="true">
+                <Column maxWidth="-1" minWidth="-1" prefWidth="15" resizable="true">
                   <Title/>
                   <Editor/>
                   <Renderer/>
@@ -118,12 +117,7 @@
                   <Editor/>
                   <Renderer/>
                 </Column>
-                <Column maxWidth="-1" minWidth="-1" prefWidth="32" resizable="false">
-                  <Title/>
-                  <Editor/>
-                  <Renderer/>
-                </Column>
-                <Column maxWidth="-1" minWidth="-1" prefWidth="32" resizable="false">
+                <Column maxWidth="-1" minWidth="-1" prefWidth="50" resizable="false">
                   <Title/>
                   <Editor/>
                   <Renderer/>

--- a/src/jdiskmark/BenchmarkPanel.java
+++ b/src/jdiskmark/BenchmarkPanel.java
@@ -6,6 +6,7 @@ import java.awt.event.ComponentEvent;
 import java.util.LinkedList;
 import java.util.List;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 
 /**
@@ -19,6 +20,16 @@ public class BenchmarkPanel extends javax.swing.JPanel {
     public BenchmarkPanel() {
         initComponents();
         Gui.runPanel = BenchmarkPanel.this;
+
+        // center align cells 2 - 11
+        for (int i = 2; i <= 11; i++) {
+            TableColumn c = runTable.getColumnModel().getColumn(i);
+            c.setCellRenderer(new CenterTableCellRenderer());
+        }
+        
+        // right align cell 12 (avg bw)
+        TableColumn c = runTable.getColumnModel().getColumn(12);
+        c.setCellRenderer(new RightTableCellRenderer());
         
         // auto scroll to bottom when a new record is added
         runTable.addComponentListener(new ComponentAdapter() {
@@ -46,11 +57,11 @@ public class BenchmarkPanel extends javax.swing.JPanel {
 
             },
             new String [] {
-                "ID", "Drive Model", "Usage", "Mode", "Order", "Samples", "Blks", "B.Size", "Start Time", "Duration (ms)", "Access (ms)", "Max (MB/s)", "Min (MB/s)", "Avg (MB/s)"
+                "ID", "Drive Model", "Usage", "Mode", "Order", "Samples", "Blocks (Size)", "Thread", "Start Time", "Time (ms)", "Acc (ms)", "Min/Max (MB/s)", "IO (MB/s)"
             }
         ) {
             boolean[] canEdit = new boolean [] {
-                false, false, false, false, false, false, false, false, false, false, false, false, false, false
+                false, false, false, false, false, false, false, false, false, false, false, false, false
             };
 
             public boolean isCellEditable(int rowIndex, int columnIndex) {
@@ -66,22 +77,22 @@ public class BenchmarkPanel extends javax.swing.JPanel {
         jScrollPane1.setViewportView(runTable);
         if (runTable.getColumnModel().getColumnCount() > 0) {
             runTable.getColumnModel().getColumn(0).setPreferredWidth(10);
-            runTable.getColumnModel().getColumn(1).setPreferredWidth(170);
-            runTable.getColumnModel().getColumn(2).setPreferredWidth(10);
-            runTable.getColumnModel().getColumn(3).setPreferredWidth(10);
+            runTable.getColumnModel().getColumn(1).setPreferredWidth(135);
+            runTable.getColumnModel().getColumn(2).setPreferredWidth(46);
+            runTable.getColumnModel().getColumn(2).setMaxWidth(45);
+            runTable.getColumnModel().getColumn(3).setPreferredWidth(6);
             runTable.getColumnModel().getColumn(4).setPreferredWidth(40);
             runTable.getColumnModel().getColumn(5).setPreferredWidth(6);
-            runTable.getColumnModel().getColumn(6).setPreferredWidth(5);
-            runTable.getColumnModel().getColumn(7).setPreferredWidth(6);
-            runTable.getColumnModel().getColumn(8).setPreferredWidth(90);
-            runTable.getColumnModel().getColumn(9).setPreferredWidth(6);
+            runTable.getColumnModel().getColumn(6).setPreferredWidth(35);
+            runTable.getColumnModel().getColumn(7).setPreferredWidth(45);
+            runTable.getColumnModel().getColumn(7).setMaxWidth(45);
+            runTable.getColumnModel().getColumn(8).setPreferredWidth(80);
+            runTable.getColumnModel().getColumn(9).setPreferredWidth(15);
             runTable.getColumnModel().getColumn(10).setPreferredWidth(10);
             runTable.getColumnModel().getColumn(11).setResizable(false);
-            runTable.getColumnModel().getColumn(11).setPreferredWidth(32);
+            runTable.getColumnModel().getColumn(11).setPreferredWidth(50);
             runTable.getColumnModel().getColumn(12).setResizable(false);
             runTable.getColumnModel().getColumn(12).setPreferredWidth(32);
-            runTable.getColumnModel().getColumn(13).setResizable(false);
-            runTable.getColumnModel().getColumn(13).setPreferredWidth(32);
         }
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
@@ -131,13 +142,12 @@ public class BenchmarkPanel extends javax.swing.JPanel {
                     run.ioMode,
                     run.blockOrder,
                     run.numSamples,
-                    run.numBlocks,
-                    run.blockSize,
+                    run.getBlocksDisplay(),
+                    run.numThreads,
                     run.getStartTimeString(),
                     run.getDuration(),
                     run.getAccTimeDisplay(),
-                    run.getBwMaxDisplay(),
-                    run.getBwMinDisplay(),
+                    run.getBwMinMaxDisplay(),
                     run.getBwAvgDisplay(),
                 });
     }

--- a/src/jdiskmark/BenchmarkWorker.java
+++ b/src/jdiskmark/BenchmarkWorker.java
@@ -126,6 +126,7 @@ public class BenchmarkWorker extends SwingWorker <Boolean, Sample> {
             run.numBlocks = App.numOfBlocks;
             run.blockSize = App.blockSizeKb;
             run.txSize = App.targetTxSizeKb();
+            run.numThreads = App.numOfThreads;
 
             Gui.chart.getTitle().setVisible(true);
             Gui.chart.getTitle().setText(run.getDriveInfo());

--- a/src/jdiskmark/CenterTableCellRenderer.java
+++ b/src/jdiskmark/CenterTableCellRenderer.java
@@ -1,0 +1,18 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package jdiskmark;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
+import java.awt.*;
+
+public class CenterTableCellRenderer extends DefaultTableCellRenderer {
+    @Override
+    public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+        Component c = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+        setHorizontalAlignment(SwingConstants.CENTER);
+        return c;
+    }
+}

--- a/src/jdiskmark/MainFrame.form
+++ b/src/jdiskmark/MainFrame.form
@@ -240,29 +240,32 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Component id="progressPanel" alignment="1" max="32767" attributes="0"/>
-          <Component id="tabbedPane" alignment="0" pref="0" max="32767" attributes="0"/>
-          <Component id="jPanel2" alignment="0" max="32767" attributes="0"/>
+          <Component id="centerPanel" alignment="0" max="32767" attributes="0"/>
+          <Group type="102" attributes="0">
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="progressPanel" max="32767" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+          </Group>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <Component id="jPanel2" min="-2" max="-2" attributes="0"/>
+              <Component id="centerPanel" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="tabbedPane" min="-2" pref="159" max="-2" attributes="0"/>
-              <EmptySpace max="32767" attributes="0"/>
               <Component id="progressPanel" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
   </Layout>
   <SubComponents>
-    <Container class="javax.swing.JPanel" name="jPanel2">
+    <Container class="javax.swing.JPanel" name="centerPanel">
 
       <Layout>
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
+              <Component id="tabbedPane" alignment="1" pref="0" max="32767" attributes="0"/>
               <Group type="102" alignment="1" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="mountPanel" max="32767" attributes="0"/>
@@ -276,11 +279,12 @@
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="controlsPanel" pref="409" max="32767" attributes="0"/>
+                  <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                      <Component id="controlsPanel" pref="393" max="32767" attributes="0"/>
                       <Component id="mountPanel" max="32767" attributes="0"/>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
+                  <Component id="tabbedPane" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -348,7 +352,7 @@
                           </Group>
                           <Component id="jPanel1" max="32767" attributes="0"/>
                       </Group>
-                      <EmptySpace pref="20" max="32767" attributes="0"/>
+                      <EmptySpace pref="35" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -819,6 +823,7 @@
             </Component>
             <Component class="javax.swing.JComboBox" name="numThreadsCombo">
               <Properties>
+                <Property name="editable" type="boolean" value="true"/>
                 <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
                   <StringArray count="5">
                     <StringItem index="0" value="1"/>
@@ -828,7 +833,7 @@
                     <StringItem index="4" value="16"/>
                   </StringArray>
                 </Property>
-                <Property name="enabled" type="boolean" value="false"/>
+                <Property name="selectedIndex" type="int" value="2"/>
               </Properties>
               <Events>
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="numThreadsComboActionPerformed"/>
@@ -836,115 +841,115 @@
             </Component>
           </SubComponents>
         </Container>
-      </SubComponents>
-    </Container>
-    <Container class="javax.swing.JTabbedPane" name="tabbedPane">
+        <Container class="javax.swing.JTabbedPane" name="tabbedPane">
 
-      <Layout class="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout"/>
-      <SubComponents>
-        <Component class="jdiskmark.BenchmarkPanel" name="runPanel">
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
-              <JTabbedPaneConstraints tabName="Benchmarks">
-                <Property name="tabTitle" type="java.lang.String" value="Benchmarks"/>
-              </JTabbedPaneConstraints>
-            </Constraint>
-          </Constraints>
-        </Component>
-        <Container class="javax.swing.JPanel" name="locationPanel">
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
-              <JTabbedPaneConstraints tabName="Drive Location">
-                <Property name="tabTitle" type="java.lang.String" value="Drive Location"/>
-              </JTabbedPaneConstraints>
-            </Constraint>
-          </Constraints>
+          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout"/>
+          <SubComponents>
+            <Component class="jdiskmark.BenchmarkPanel" name="runPanel">
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
+                  <JTabbedPaneConstraints tabName="Benchmarks">
+                    <Property name="tabTitle" type="java.lang.String" value="Benchmarks"/>
+                  </JTabbedPaneConstraints>
+                </Constraint>
+              </Constraints>
+            </Component>
+            <Container class="javax.swing.JPanel" name="locationPanel">
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
+                  <JTabbedPaneConstraints tabName="Drive Location">
+                    <Property name="tabTitle" type="java.lang.String" value="Drive Location"/>
+                  </JTabbedPaneConstraints>
+                </Constraint>
+              </Constraints>
 
-          <Layout>
-            <DimensionLayout dim="0">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="locationText" min="-2" pref="480" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="jLabel15" pref="314" max="32767" attributes="0"/>
-                      <EmptySpace type="separate" max="-2" attributes="0"/>
-                      <Component id="chooseButton" min="-2" pref="100" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="openLocButton" min="-2" pref="74" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                  </Group>
-              </Group>
-            </DimensionLayout>
-            <DimensionLayout dim="1">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="3" attributes="0">
-                          <Component id="locationText" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="chooseButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="openLocButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="jLabel15" alignment="3" min="-2" max="-2" attributes="0"/>
+              <Layout>
+                <DimensionLayout dim="0">
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="locationText" min="-2" pref="480" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="jLabel15" pref="314" max="32767" attributes="0"/>
+                          <EmptySpace type="separate" max="-2" attributes="0"/>
+                          <Component id="chooseButton" min="-2" pref="100" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="openLocButton" min="-2" pref="74" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace pref="94" max="32767" attributes="0"/>
                   </Group>
-              </Group>
-            </DimensionLayout>
-          </Layout>
-          <SubComponents>
-            <Component class="javax.swing.JButton" name="chooseButton">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Browse"/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="chooseButtonActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JTextField" name="locationText">
-              <Properties>
-                <Property name="editable" type="boolean" value="false"/>
-              </Properties>
-            </Component>
-            <Component class="javax.swing.JButton" name="openLocButton">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Open"/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="openLocButtonActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JLabel" name="jLabel15">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="/jDiskMarkData"/>
-              </Properties>
-            </Component>
-          </SubComponents>
-        </Container>
-        <Container class="javax.swing.JScrollPane" name="eventScrollPane">
-          <AuxValues>
-            <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
-          </AuxValues>
-          <Constraints>
-            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
-              <JTabbedPaneConstraints tabName="Event Log">
-                <Property name="tabTitle" type="java.lang.String" value="Event Log"/>
-              </JTabbedPaneConstraints>
-            </Constraint>
-          </Constraints>
+                </DimensionLayout>
+                <DimensionLayout dim="1">
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="3" attributes="0">
+                              <Component id="locationText" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="chooseButton" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="openLocButton" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="jLabel15" alignment="3" min="-2" max="-2" attributes="0"/>
+                          </Group>
+                          <EmptySpace pref="123" max="32767" attributes="0"/>
+                      </Group>
+                  </Group>
+                </DimensionLayout>
+              </Layout>
+              <SubComponents>
+                <Component class="javax.swing.JButton" name="chooseButton">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Browse"/>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="chooseButtonActionPerformed"/>
+                  </Events>
+                </Component>
+                <Component class="javax.swing.JTextField" name="locationText">
+                  <Properties>
+                    <Property name="editable" type="boolean" value="false"/>
+                  </Properties>
+                </Component>
+                <Component class="javax.swing.JButton" name="openLocButton">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Open"/>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="openLocButtonActionPerformed"/>
+                  </Events>
+                </Component>
+                <Component class="javax.swing.JLabel" name="jLabel15">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="/jDiskMarkData"/>
+                  </Properties>
+                </Component>
+              </SubComponents>
+            </Container>
+            <Container class="javax.swing.JScrollPane" name="eventScrollPane">
+              <AuxValues>
+                <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
+              </AuxValues>
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
+                  <JTabbedPaneConstraints tabName="Event Log">
+                    <Property name="tabTitle" type="java.lang.String" value="Event Log"/>
+                  </JTabbedPaneConstraints>
+                </Constraint>
+              </Constraints>
 
-          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
-          <SubComponents>
-            <Component class="javax.swing.JTextArea" name="msgTextArea">
-              <Properties>
-                <Property name="editable" type="boolean" value="false"/>
-                <Property name="columns" type="int" value="20"/>
-                <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
-                  <Font name="Monospaced" size="11" style="0"/>
-                </Property>
-                <Property name="rows" type="int" value="5"/>
-                <Property name="tabSize" type="int" value="4"/>
-              </Properties>
-            </Component>
+              <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+              <SubComponents>
+                <Component class="javax.swing.JTextArea" name="msgTextArea">
+                  <Properties>
+                    <Property name="editable" type="boolean" value="false"/>
+                    <Property name="columns" type="int" value="20"/>
+                    <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                      <Font name="Monospaced" size="11" style="0"/>
+                    </Property>
+                    <Property name="rows" type="int" value="5"/>
+                    <Property name="tabSize" type="int" value="4"/>
+                  </Properties>
+                </Component>
+              </SubComponents>
+            </Container>
           </SubComponents>
         </Container>
       </SubComponents>
@@ -954,23 +959,18 @@
       <Layout>
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="1" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="jLabel7" min="-2" pref="89" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
+              <Group type="102" alignment="0" attributes="0">
+                  <Component id="jLabel7" min="-2" pref="83" max="-2" attributes="0"/>
+                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
                   <Component id="totalTxProgBar" min="-2" pref="903" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Component id="jLabel7" alignment="1" max="32767" attributes="0"/>
-              <Group type="102" alignment="1" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="totalTxProgBar" max="32767" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-              </Group>
+              <Component id="totalTxProgBar" alignment="1" max="32767" attributes="0"/>
           </Group>
         </DimensionLayout>
       </Layout>

--- a/src/jdiskmark/MainFrame.java
+++ b/src/jdiskmark/MainFrame.java
@@ -131,7 +131,7 @@ public final class MainFrame extends javax.swing.JFrame {
     private void initComponents() {
 
         palettebuttonGroup = new javax.swing.ButtonGroup();
-        jPanel2 = new javax.swing.JPanel();
+        centerPanel = new javax.swing.JPanel();
         mountPanel = new javax.swing.JPanel();
         controlsPanel = new javax.swing.JPanel();
         numBlocksCombo = new javax.swing.JComboBox();
@@ -447,8 +447,9 @@ public final class MainFrame extends javax.swing.JFrame {
 
         jLabel21.setText("Number Threads");
 
+        numThreadsCombo.setEditable(true);
         numThreadsCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "1", "2", "4", "8", "16" }));
-        numThreadsCombo.setEnabled(false);
+        numThreadsCombo.setSelectedIndex(2);
         numThreadsCombo.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 numThreadsComboActionPerformed(evt);
@@ -482,7 +483,7 @@ public final class MainFrame extends javax.swing.JFrame {
                             .addComponent(modeCombo, javax.swing.GroupLayout.Alignment.TRAILING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addComponent(numThreadsCombo, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
                     .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addContainerGap(20, Short.MAX_VALUE))
+                .addContainerGap(35, Short.MAX_VALUE))
         );
         controlsPanelLayout.setVerticalGroup(
             controlsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -518,27 +519,6 @@ public final class MainFrame extends javax.swing.JFrame {
                 .addComponent(startButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap())
-        );
-
-        javax.swing.GroupLayout jPanel2Layout = new javax.swing.GroupLayout(jPanel2);
-        jPanel2.setLayout(jPanel2Layout);
-        jPanel2Layout.setHorizontalGroup(
-            jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel2Layout.createSequentialGroup()
-                .addContainerGap()
-                .addComponent(mountPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(controlsPanel, javax.swing.GroupLayout.PREFERRED_SIZE, 261, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap())
-        );
-        jPanel2Layout.setVerticalGroup(
-            jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jPanel2Layout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(controlsPanel, javax.swing.GroupLayout.PREFERRED_SIZE, 409, Short.MAX_VALUE)
-                    .addComponent(mountPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap())
         );
 
@@ -586,7 +566,7 @@ public final class MainFrame extends javax.swing.JFrame {
                     .addComponent(chooseButton)
                     .addComponent(openLocButton)
                     .addComponent(jLabel15))
-                .addContainerGap(94, Short.MAX_VALUE))
+                .addContainerGap(123, Short.MAX_VALUE))
         );
 
         tabbedPane.addTab("Drive Location", locationPanel);
@@ -600,6 +580,29 @@ public final class MainFrame extends javax.swing.JFrame {
 
         tabbedPane.addTab("Event Log", eventScrollPane);
 
+        javax.swing.GroupLayout centerPanelLayout = new javax.swing.GroupLayout(centerPanel);
+        centerPanel.setLayout(centerPanelLayout);
+        centerPanelLayout.setHorizontalGroup(
+            centerPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addComponent(tabbedPane, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE)
+            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, centerPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(mountPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(controlsPanel, javax.swing.GroupLayout.PREFERRED_SIZE, 261, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap())
+        );
+        centerPanelLayout.setVerticalGroup(
+            centerPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(centerPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(centerPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                    .addComponent(controlsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 393, Short.MAX_VALUE)
+                    .addComponent(mountPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(tabbedPane))
+        );
+
         jLabel7.setHorizontalAlignment(javax.swing.SwingConstants.LEFT);
         jLabel7.setText("Total Tx (KB)");
 
@@ -607,20 +610,16 @@ public final class MainFrame extends javax.swing.JFrame {
         progressPanel.setLayout(progressPanelLayout);
         progressPanelLayout.setHorizontalGroup(
             progressPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, progressPanelLayout.createSequentialGroup()
-                .addContainerGap()
-                .addComponent(jLabel7, javax.swing.GroupLayout.PREFERRED_SIZE, 89, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+            .addGroup(progressPanelLayout.createSequentialGroup()
+                .addComponent(jLabel7, javax.swing.GroupLayout.PREFERRED_SIZE, 83, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(totalTxProgBar, javax.swing.GroupLayout.PREFERRED_SIZE, 903, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap())
+                .addGap(0, 0, Short.MAX_VALUE))
         );
         progressPanelLayout.setVerticalGroup(
             progressPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addComponent(jLabel7, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, progressPanelLayout.createSequentialGroup()
-                .addContainerGap()
-                .addComponent(totalTxProgBar, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addContainerGap())
+            .addComponent(totalTxProgBar, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
 
         fileMenu.setText("File");
@@ -807,18 +806,19 @@ public final class MainFrame extends javax.swing.JFrame {
         getContentPane().setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(progressPanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-            .addComponent(tabbedPane, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE)
-            .addComponent(jPanel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addComponent(centerPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addGroup(layout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(progressPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addContainerGap())
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addComponent(jPanel2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(centerPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(tabbedPane, javax.swing.GroupLayout.PREFERRED_SIZE, 159, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addComponent(progressPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addComponent(progressPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap())
         );
 
         pack();
@@ -992,7 +992,10 @@ public final class MainFrame extends javax.swing.JFrame {
     }//GEN-LAST:event_resetBenchmarkItemActionPerformed
 
     private void numThreadsComboActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_numThreadsComboActionPerformed
-        // TODO add your handling code here:
+        if (numThreadsCombo.hasFocus()) {
+            App.numOfThreads = Integer.parseInt((String) numThreadsCombo.getSelectedItem());
+            App.saveConfig();
+        }
     }//GEN-LAST:event_numThreadsComboActionPerformed
 
 
@@ -1004,6 +1007,7 @@ public final class MainFrame extends javax.swing.JFrame {
     private javax.swing.JRadioButtonMenuItem bardWarmPaletteMenuItem;
     private javax.swing.JComboBox blockSizeCombo;
     private javax.swing.JRadioButtonMenuItem blueGreenPaletteMenuItem;
+    private javax.swing.JPanel centerPanel;
     private javax.swing.JButton chooseButton;
     private javax.swing.JRadioButtonMenuItem classicPaletteMenuItem;
     private javax.swing.JMenuItem clearLogsItem;
@@ -1040,7 +1044,6 @@ public final class MainFrame extends javax.swing.JFrame {
     private javax.swing.JMenuItem jMenuItem1;
     private javax.swing.JMenuItem jMenuItem2;
     private javax.swing.JPanel jPanel1;
-    private javax.swing.JPanel jPanel2;
     private javax.swing.JPopupMenu.Separator jSeparator1;
     private javax.swing.JPopupMenu.Separator jSeparator2;
     private javax.swing.JPanel locationPanel;
@@ -1092,9 +1095,10 @@ public final class MainFrame extends javax.swing.JFrame {
         App.readTest = modeStr.contains("read");
         App.writeTest = modeStr.contains("write");
         App.blockSequence = (Benchmark.BlockSequence)orderComboBox.getSelectedItem();
-        App.numOfSamples = Integer.parseInt((String) numFilesCombo.getSelectedItem());
-        App.numOfBlocks = Integer.parseInt((String) numBlocksCombo.getSelectedItem());
-        App.blockSizeKb = Integer.parseInt((String) blockSizeCombo.getSelectedItem());
+        App.numOfSamples = Integer.parseInt((String)numFilesCombo.getSelectedItem());
+        App.numOfBlocks = Integer.parseInt((String)numBlocksCombo.getSelectedItem());
+        App.blockSizeKb = Integer.parseInt((String)blockSizeCombo.getSelectedItem());
+        App.numOfThreads = Integer.parseInt((String)numThreadsCombo.getSelectedItem());
         sampleSizeLabel.setText(String.valueOf(App.targetMarkSizeKb()));
         totalTxProgBar.setString(String.valueOf(App.targetTxSizeKb()));
     }

--- a/src/jdiskmark/RightTableCellRenderer.java
+++ b/src/jdiskmark/RightTableCellRenderer.java
@@ -1,0 +1,18 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package jdiskmark;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
+import java.awt.*;
+
+public class RightTableCellRenderer extends DefaultTableCellRenderer {
+    @Override
+    public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+        Component c = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+        setHorizontalAlignment(SwingConstants.RIGHT);
+        return c;
+    }
+}


### PR DESCRIPTION
Changes are 
1. basic threading but from testing it looks that more threads = slower so not sure what is going on there. wondering if there is something i'm overlooking.
2. adjusted panels so that dragging windows bottom will expand the benchmark history to show more records.
3. also would value feedback on if I should add queue depth support now or break it out into a separate issue that we defer till after the web portal. If now I probably need to understand how to implement the benchmark better to control the queue depth. i think we need to monitor the number of open request per thread.

![image](https://github.com/user-attachments/assets/ba399b89-d3d4-48d4-8cb3-ae26f26ed2bc)

also now we can grab the bottom of the window and drag down to see more benchmark records at once

![image](https://github.com/user-attachments/assets/a02b4618-5026-4ffe-8a7e-d517a2b8c31a)

Here is a build of this feature on sourceforge: [jdiskmark-0.6.0-dev.f.threading.zip](https://sourceforge.net/projects/jdiskmark/files/jdiskmark-0.6.0-dev.f.threading.zip/download)
