### PR TITLE
Issue #64: Persist Write Sync + show as “Write*” in Mode (deprecated)

### DIFF
--- a/src/jdiskmark/Benchmark.java
+++ b/src/jdiskmark/Benchmark.java
@@ -103,6 +103,10 @@ public class Benchmark implements Serializable {
     @Column
     int numThreads = 1;
     
+    // NEW: whether write-sync was enabled for this run (only meaningful for WRITE; may be null for READ)
+    @Column
+    Boolean writeSyncEnabled;
+    
     // timestamps
     @Convert(converter = LocalDateTimeAttributeConverter.class)
     @Column(name = "startTime", columnDefinition = "TIMESTAMP")
@@ -214,6 +218,24 @@ public class Benchmark implements Serializable {
             double iopsDouble = (double) (totalOps * 1_000_000) / (double) diffMs;
             iops = Math.round(iopsDouble);
         }
+    }
+    
+    // NEW: getters/setters for writeSyncEnabled and iops (expose iops too if needed)
+
+    public Boolean getWriteSyncEnabled() {
+        return writeSyncEnabled;
+    }
+
+    public void setWriteSyncEnabled(Boolean writeSyncEnabled) {
+        this.writeSyncEnabled = writeSyncEnabled;
+    }
+
+    public long getIops() {
+        return iops;
+    }
+
+    public void setIops(long iops) {
+        this.iops = iops;
     }
     
     // utility methods for collection

--- a/src/jdiskmark/BenchmarkPanel.java
+++ b/src/jdiskmark/BenchmarkPanel.java
@@ -18,27 +18,32 @@ public class BenchmarkPanel extends javax.swing.JPanel {
      * Creates new form TestPanel
      */
     public BenchmarkPanel() {
-        initComponents();
-        Gui.runPanel = BenchmarkPanel.this;
+    initComponents();
+    Gui.runPanel = BenchmarkPanel.this;
 
-        // center align cells 2 - 11
-        for (int i = 2; i <= 11; i++) {
-            TableColumn c = runTable.getColumnModel().getColumn(i);
-            c.setCellRenderer(new CenterTableCellRenderer());
-        }
-        
-        // right align cell 12 (avg bw)
-        TableColumn c = runTable.getColumnModel().getColumn(12);
-        c.setCellRenderer(new RightTableCellRenderer());
-        
-        // auto scroll to bottom when a new record is added
-        runTable.addComponentListener(new ComponentAdapter() {
-            @Override
-            public void componentResized(ComponentEvent e) {
-                runTable.scrollRectToVisible(runTable.getCellRect(runTable.getRowCount()-1, 0, true));
-            }
-        });
+    // Tooltip only – keep it simple
+    runTable.setToolTipText("Mode: Write* means Write Sync was enabled");
+
+    // center align cells 2 - 11
+    for (int i = 2; i <= 11; i++) {
+        TableColumn c = runTable.getColumnModel().getColumn(i);
+        c.setCellRenderer(new CenterTableCellRenderer());
     }
+
+    // right align cell 12 (avg bw)
+    TableColumn c = runTable.getColumnModel().getColumn(12);
+    c.setCellRenderer(new RightTableCellRenderer());
+
+    // auto scroll to bottom when a new record is added
+    runTable.addComponentListener(new ComponentAdapter() {
+        @Override
+        public void componentResized(ComponentEvent e) {
+            runTable.scrollRectToVisible(
+                runTable.getCellRect(runTable.getRowCount() - 1, 0, true)
+            );
+        }
+    });
+}
 
     /**
      * This method is called from within the constructor to initialize the form.
@@ -132,6 +137,13 @@ public class BenchmarkPanel extends javax.swing.JPanel {
     private javax.swing.JTable runTable;
     // End of variables declaration//GEN-END:variables
 
+    private String getModeDisplay(Benchmark run) {
+    if (run.ioMode == Benchmark.IOMode.WRITE && Boolean.TRUE.equals(run.getWriteSyncEnabled())) {
+        return "Write*";
+    }
+    return run.ioMode.toString(); // "Read", "Write", or "Read & Write"
+}
+
     public void addRun(Benchmark run) {
         DefaultTableModel model = (DefaultTableModel) this.runTable.getModel();
         model.addRow(
@@ -139,7 +151,7 @@ public class BenchmarkPanel extends javax.swing.JPanel {
                     run.id,
                     run.driveModel,
                     run.getUsageColumnDisplay(),
-                    run.ioMode,
+                    getModeDisplay(run),                     
                     run.blockOrder,
                     run.numSamples,
                     run.getBlocksDisplay(),

--- a/src/jdiskmark/BenchmarkWorker.java
+++ b/src/jdiskmark/BenchmarkWorker.java
@@ -128,6 +128,10 @@ public class BenchmarkWorker extends SwingWorker <Boolean, Sample> {
             run.blockSize = App.blockSizeKb;
             run.txSize = App.targetTxSizeKb();
             run.numThreads = App.numOfThreads;
+            
+            // persist whether write sync was enabled for this run
+            run.setWriteSyncEnabled(App.writeSyncEnable);
+
 
             Gui.chart.getTitle().setVisible(true);
             Gui.chart.getTitle().setText(run.getDriveInfo());
@@ -239,6 +243,10 @@ public class BenchmarkWorker extends SwingWorker <Boolean, Sample> {
             run.numBlocks = App.numOfBlocks;
             run.blockSize = App.blockSizeKb;
             run.txSize = App.targetTxSizeKb();
+            
+            // write sync does not apply to pure read benchmarks
+            run.setWriteSyncEnabled(null);
+
 
             Gui.chart.getTitle().setVisible(true);
             Gui.chart.getTitle().setText(run.getDriveInfo());


### PR DESCRIPTION
Summary
- Implements Issue #64 by persisting whether Write Sync was enabled for a run
  and reflecting it in the results table without adding a new column.

Changes
- Benchmark.java: add `Boolean writeSyncEnabled` with getters/setters.
- BenchmarkWorker.java:
  - On WRITE: persist current App.writeSyncEnable value.
  - On READ: set to null.
- BenchmarkPanel.java:
  - Display Mode as “Write*” when write sync was enabled.
  - Kept layout unchanged; removed earlier forced width overrides.
  - Added tooltip: "Mode: Write* means Write Sync was enabled".

Testing
- Verified WRITE benchmarks display “Write” when sync disabled and “Write*” when enabled.
- Verified READ benchmarks display “Read”.
- Restarted app; persisted results reload correctly (asterisk included).
- No regressions in metrics, persistence, or UI.

Notes
- Followed the asterisk approach to avoid adding a column, per guidance.
- Kept UI code lean and maintainable.
