### PR TITLE
#73 New data model

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Java 21 needs to be installed to run jdiskmark.
 3. Extract release zip archive into desired location.
    ```
    Examples:  
-   /Users/username/jdiskmark-v0.6.0  
+   /Users/username/jdiskmark-v0.6.0
    /opt/jdiskmark-v0.6.0
    ```
 
@@ -84,6 +84,7 @@ Source code is available on our [github repo](https://github.com/JDiskMark/jdm-j
 - TODO: #33 maven build - lane
 - TODO: #40 gui presentation issues - james
 - #84 processor info resolved for (sp) installs
+- #73 refactor benchmark data model, keyboard op sel
 
 ### v0.6.2 linux optimized ui
 - #64 persist IOPS, write sync - val

--- a/build.xml
+++ b/build.xml
@@ -83,12 +83,12 @@
     <!-- version properties -->
     <property name="pkg.name" value="jdiskmark"/>
     <property name="app.name" value="JDiskMark"/>
-    <property name="version" value="0.6.2"/>
+    <property name="version" value="0.6.3-dev"/>
     <!-- full semver does not work for msi product versions -->
-    <property name="msi.version" value="0.6.2"/>
+    <property name="msi.version" value="0.6.3"/>
     <property name="msi.app.title" value="${app.name} ${version}"/>
     <property name="release.dir" value="${pkg.name}-${version}"/>
-    <property name="dmg.version" value="1.6.0"/>
+    <property name="dmg.version" value="1.6.3"/>
 
     <!-- msi signing properties -->
     <property name="timestamp.server.url" value="http://timestamp.sectigo.com"/>

--- a/src/META-INF/persistence.xml
+++ b/src/META-INF/persistence.xml
@@ -7,7 +7,11 @@
       <property name="jakarta.persistence.jdbc.url" value="jdbc:derby:derbyDB;create=true"/>
       <property name="jakarta.persistence.jdbc.driver" value="org.apache.derby.jdbc.EmbeddedDriver"/>
       <property name="eclipselink.logging.level" value="FINE"/>
-      <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
+      <!-- per gemini this is deprecated -->
+      <!--<property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>-->
+      <!-- this will drop and create a new db every time, useful for testing -->
+      <!--<property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>-->
+      <property name="jakarta.persistence.schema-generation.database.action" value="create-or-extend-tables"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/src/jdiskmark/Benchmark.java
+++ b/src/jdiskmark/Benchmark.java
@@ -89,17 +89,6 @@ public class Benchmark implements Serializable {
     @Column
     LocalDateTime endTime = null;
 
-    // results
-    @Column
-    double bwAvg = 0;
-    @Column
-    double bwMax = 0;
-    @Column
-    double bwMin = 0;
-    @Column
-    double accAvg = 0;
-    @Column
-    long iops = 0;
     
     @OneToMany(mappedBy = "benchmark", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BenchmarkOperation> operations = new ArrayList<>();
@@ -120,7 +109,7 @@ public class Benchmark implements Serializable {
     
     @Override
     public String toString() {
-        return "Benchmark(" + benchmarkType + "):  bw: " + bwAvg;
+        return "Benchmark(" + benchmarkType + ") start=" + startTime + "numOps=" + operations.size();
     }
     
     public Benchmark() {
@@ -160,29 +149,9 @@ public class Benchmark implements Serializable {
 //    public String getBlocksDisplay() {
 //        return numBlocks + " (" + blockSize + ")";
 //    }
-    
+   
     public String getStartTimeString() {
         return startTime.format(DATE_FORMAT);
-    }
-    
-    public String getAccTimeDisplay() {
-        return accAvg == -1? "- -" : DF.format(accAvg);
-    }
-    
-    public String getBwMinDisplay() {
-        return bwMin == -1 ? "- -" : DF.format(bwMin);
-    }
-    
-    public String getBwMaxDisplay() {
-        return bwMax == -1 ? "- -" : DF.format(bwMax);
-    }
-    
-    public String getBwMinMaxDisplay() {
-        return bwMax == -1 ? "- -" : DFT.format(bwMin) + "/" + DFT.format(bwMax);
-    }
-    
-    public String getBwAvgDisplay() {
-        return bwAvg == -1 ? "- -" : DF.format(bwAvg);
     }
     
     public String getDuration() {
@@ -191,26 +160,6 @@ public class Benchmark implements Serializable {
         }
         long diffMs = Duration.between(startTime, endTime).toMillis();
         return String.valueOf(diffMs);
-    }
-    
-    public void setTotalOps(long totalOps) {
-        // iops = operations / sec = ops / (elapsed ms / 1,000ms)
-        // Multiply by 1_000_000 to convert milliseconds to seconds
-        System.err.println("startTime=" + startTime);
-        System.err.println("endTime=" + endTime);
-        long diffMs = Duration.between(startTime, endTime).toMillis();
-        if (diffMs != 0) {
-            double iopsDouble = (double) (totalOps * 1_000_000) / (double) diffMs;
-            iops = Math.round(iopsDouble);
-        }
-    }
-
-    public long getIops() {
-        return iops;
-    }
-
-    public void setIops(long iops) {
-        this.iops = iops;
     }
     
     // utility methods for collection

--- a/src/jdiskmark/Benchmark.java
+++ b/src/jdiskmark/Benchmark.java
@@ -138,18 +138,7 @@ public class Benchmark implements Serializable {
     public String getUsageColumnDisplay() {
         return percentUsed + "%";
     }
-    
-    // GH-20 TODO: review should this be synchronized or redone to not be blocking?
-//    public synchronized void add(Sample s) {
-//        samples.add(s);
-//    }
-    
-    // display friendly methods
-    
-//    public String getBlocksDisplay() {
-//        return numBlocks + " (" + blockSize + ")";
-//    }
-   
+       
     public String getStartTimeString() {
         return startTime.format(DATE_FORMAT);
     }

--- a/src/jdiskmark/BenchmarkOperation.java
+++ b/src/jdiskmark/BenchmarkOperation.java
@@ -1,17 +1,18 @@
 
 package jdiskmark;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.io.Serializable;
 import java.text.DecimalFormat;
@@ -25,18 +26,18 @@ import java.util.List;
  * A read or write benchmark
  */
 @Entity
-@Table(name="Benchmark")
+@Table(name="BenchmarkOperation")
 @NamedQueries({
-@NamedQuery(name="Benchmark.findAll",
-    query="SELECT b FROM Benchmark b JOIN FETCH b.operations")
+@NamedQuery(name="BenchmarkOperation.findAll",
+    query="SELECT d FROM BenchmarkOperation d")
 })
-public class Benchmark implements Serializable {
+public class BenchmarkOperation implements Serializable {
     
     static final DecimalFormat DF = new DecimalFormat("###.##");
     static final DecimalFormat DFT = new DecimalFormat("###");
     static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     
-    public enum BenchmarkType {
+    public enum IOMode {
         READ {
             @Override
             public String toString() { return "Read"; }
@@ -44,10 +45,17 @@ public class Benchmark implements Serializable {
         WRITE {
             @Override
             public String toString() { return "Write"; }
-        },
-        READ_WRITE {    
+        }
+    }
+
+    public enum BlockSequence {
+        SEQUENTIAL {
             @Override
-            public String toString() { return "Read & Write"; }
+            public String toString() { return "Sequential"; }
+        },
+        RANDOM {
+            @Override
+            public String toString() { return "Random"; }
         }
     }
     
@@ -57,30 +65,30 @@ public class Benchmark implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     long id;
     
-    // system data
-    @Column
-    String os;
-    @Column
-    String arch;
-    @Column
-    String processorName;
-    
-    // drive info
-    @Column
-    String driveModel = null;
-    @Column
-    String partitionId;      // on windows the drive letter
-    @Column
-    long percentUsed;
-    @Column
-    double usedGb;
-    @Column
-    double totalGb;
+    // This is the foreign key relationship
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "benchmark_id") // Specifies the foreign key column
+    private Benchmark benchmark;
     
     // benchmark parameters
     @Column
-    BenchmarkType benchmarkType;
-
+    IOMode ioMode;
+    @Column
+    BlockSequence blockOrder;
+    @Column
+    int numBlocks = 0;
+    @Column
+    int blockSize = 0;
+    @Column
+    int numSamples = 0;
+    @Column
+    long txSize = 0;
+    @Column
+    int numThreads = 1;
+    // NEW: whether write-sync was enabled for this run (only meaningful for WRITE; may be null for READ)
+    @Column
+    Boolean writeSyncEnabled;
+    
     // timestamps
     @Convert(converter = LocalDateTimeAttributeConverter.class)
     @Column(name = "startTime", columnDefinition = "TIMESTAMP")
@@ -88,7 +96,12 @@ public class Benchmark implements Serializable {
     @Convert(converter = LocalDateTimeAttributeConverter.class)
     @Column
     LocalDateTime endTime = null;
-
+    
+    // sample data
+    @Column
+    @Convert(converter = SampleAttributeConverter.class)
+    ArrayList<Sample> samples = new ArrayList<>();
+    
     // results
     @Column
     double bwAvg = 0;
@@ -101,65 +114,58 @@ public class Benchmark implements Serializable {
     @Column
     long iops = 0;
     
-    @OneToMany(mappedBy = "benchmark", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<BenchmarkOperation> operations = new ArrayList<>();
-    
-    public List<BenchmarkOperation> getOperations() {
-        return operations;
-    }
-    
-    // get the first operation of that type
-    public BenchmarkOperation getOperation(BenchmarkOperation.IOMode mode) {
-        for (BenchmarkOperation operation : operations) {
-            if (operation.ioMode == mode) {
-                return operation;
-            }
-        }
-        return null;
-    }
-    
     @Override
     public String toString() {
-        return "Benchmark(" + benchmarkType + "):  bw: " + bwAvg;
+        return "BenchmarkOp(" + ioMode + "," + blockOrder + "): " + numSamples + " bw avg: " + bwAvg;
     }
     
-    public Benchmark() {
+    public BenchmarkOperation() {
         startTime = LocalDateTime.now();
     }
     
-    Benchmark(BenchmarkType type) {
+    BenchmarkOperation(IOMode type, BlockSequence order) {
         startTime = LocalDateTime.now();
-        benchmarkType = type;
+        ioMode = type;
+        blockOrder = order;
     }
     
     // basic getters and setters
-    
+    public Benchmark getBenchmark() {
+        return benchmark;
+    }
+    public void setBenchmark(Benchmark benchmark) {
+        this.benchmark = benchmark;
+    }    
     public Long getId() {
         return id;
     }
     public void setId(Long id) {
         this.id = id;
     }
-    public String getDriveInfo() {
-        return driveModel + " - " + partitionId + ": " + getUsageTitleDisplay();
+    
+    public String getModeDisplay() {
+        // Show "Write*" when write-sync was enabled for a WRITE run
+        if (ioMode == IOMode.WRITE && Boolean.TRUE.equals(getWriteSyncEnabled())) {
+            return "Write*";
+        }
+        return (ioMode == null) ? "" : ioMode.toString(); // "Read", "Write", "Read & Write"
     }
-    public String getUsageTitleDisplay() {
-        return  percentUsed + "% (" + DFT.format(usedGb) + "/" + DFT.format(totalGb) + " GB)";
-    }
-    public String getUsageColumnDisplay() {
-        return percentUsed + "%";
-    }
+
     
     // GH-20 TODO: review should this be synchronized or redone to not be blocking?
-//    public synchronized void add(Sample s) {
-//        samples.add(s);
-//    }
+    public synchronized void add(Sample s) {
+        samples.add(s);
+    }
+    
+    public synchronized ArrayList<Sample> getSamples() {
+        return samples;
+    }
     
     // display friendly methods
     
-//    public String getBlocksDisplay() {
-//        return numBlocks + " (" + blockSize + ")";
-//    }
+    public String getBlocksDisplay() {
+        return numBlocks + " (" + blockSize + ")";
+    }
     
     public String getStartTimeString() {
         return startTime.format(DATE_FORMAT);
@@ -204,6 +210,16 @@ public class Benchmark implements Serializable {
             iops = Math.round(iopsDouble);
         }
     }
+    
+    // NEW: getters/setters for writeSyncEnabled and iops (expose iops too if needed)
+
+    public Boolean getWriteSyncEnabled() {
+        return writeSyncEnabled;
+    }
+
+    public void setWriteSyncEnabled(Boolean writeSyncEnabled) {
+        this.writeSyncEnabled = writeSyncEnabled;
+    }
 
     public long getIops() {
         return iops;
@@ -215,36 +231,26 @@ public class Benchmark implements Serializable {
     
     // utility methods for collection
     
-    static List<Benchmark> findAll() {
+    static List<BenchmarkOperation> findAll() {
         EntityManager em = EM.getEntityManager();
-        return em.createNamedQuery("Benchmark.findAll", Benchmark.class).getResultList();
+        return em.createNamedQuery("Benchmark.findAll", BenchmarkOperation.class).getResultList();
     }
     
     static int deleteAll() {
         EntityManager em = EM.getEntityManager();
         em.getTransaction().begin();
-        int deletedOperationsCount = em.createQuery("DELETE FROM BenchmarkOperation").executeUpdate();
-        int deletedBenchmarksCount = em.createQuery("DELETE FROM Benchmark").executeUpdate();
+        int deletedCount = em.createQuery("DELETE FROM Benchmark").executeUpdate();
         em.getTransaction().commit();
-        return deletedBenchmarksCount;
+        return deletedCount;
     }
     
     static int delete(List<Long> benchmarkIds) {
         EntityManager em = EM.getEntityManager();
         em.getTransaction().begin();
-        
-        // delete the child BenchmarkOperation records.
-        String deleteOperationsJpql = "DELETE FROM BenchmarkOperation bo WHERE bo.benchmark.id IN :benchmarkIds";
-        int deletedOpsCount = em.createQuery(deleteOperationsJpql)
+        String jpql = "DELETE FROM Benchmark b WHERE b.id IN :benchmarkIds";
+        int deletedCount = em.createQuery(jpql)
                 .setParameter("benchmarkIds", benchmarkIds)
                 .executeUpdate();
-        
-        // delete the parent BenchmarkOperation records
-        String deleteBenchmarksJpql = "DELETE FROM Benchmark b WHERE b.id IN :benchmarkIds";
-        int deletedCount = em.createQuery(deleteBenchmarksJpql)
-                .setParameter("benchmarkIds", benchmarkIds)
-                .executeUpdate();
-        
         em.getTransaction().commit();
         return deletedCount;
     }

--- a/src/jdiskmark/BenchmarkPanel.form
+++ b/src/jdiskmark/BenchmarkPanel.form
@@ -136,9 +136,6 @@
               <TableHeader reorderingAllowed="true" resizingAllowed="true"/>
             </Property>
           </Properties>
-          <Events>
-            <EventHandler event="mouseClicked" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="runTableMouseClicked"/>
-          </Events>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_SerializeTo" type="java.lang.String" value="BenchmarkPanel_runTable"/>
           </AuxValues>

--- a/src/jdiskmark/BenchmarkPanel.form
+++ b/src/jdiskmark/BenchmarkPanel.form
@@ -48,7 +48,7 @@
                 <Column editable="false" title="ID" type="java.lang.Object"/>
                 <Column editable="false" title="Drive Model" type="java.lang.Object"/>
                 <Column editable="false" title="Usage" type="java.lang.Object"/>
-                <Column editable="false" title="Mode" type="java.lang.Object"/>
+                <Column editable="false" title="Type" type="java.lang.Object"/>
                 <Column editable="false" title="Order" type="java.lang.Object"/>
                 <Column editable="false" title="Samples" type="java.lang.Object"/>
                 <Column editable="false" title="Blocks (Size)" type="java.lang.Object"/>

--- a/src/jdiskmark/BenchmarkPanel.java
+++ b/src/jdiskmark/BenchmarkPanel.java
@@ -62,7 +62,7 @@ public class BenchmarkPanel extends javax.swing.JPanel {
 
             },
             new String [] {
-                "ID", "Drive Model", "Usage", "Mode", "Order", "Samples", "Blocks (Size)", "Thread", "Start Time", "Time (ms)", "Acc (ms)", "Min/Max (MB/s)", "IO (MB/s)"
+                "ID", "Drive Model", "Usage", "Type", "Order", "Samples", "Blocks (Size)", "Thread", "Start Time", "Time (ms)", "Acc (ms)", "Min/Max (MB/s)", "IO (MB/s)"
             }
         ) {
             boolean[] canEdit = new boolean [] {
@@ -123,11 +123,10 @@ public class BenchmarkPanel extends javax.swing.JPanel {
     private void runTableMouseClicked(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_runTableMouseClicked
         int sRow = runTable.getSelectedRow();
         String timeString = (String) runTable.getValueAt(sRow, START_TIME_COLUMN);
-        System.out.println("timeString=" + timeString);
-
-        Benchmark benchmark = App.benchmarks.get(timeString);
-        if (benchmark != null) {
-            Gui.loadBenchmark(benchmark);
+        System.out.println("selected operation starttime=" + timeString);
+        BenchmarkOperation operation = App.operations.get(timeString);
+        if (operation != null) {
+            Gui.loadOperation(operation);
         }
     }//GEN-LAST:event_runTableMouseClicked
 
@@ -139,23 +138,28 @@ public class BenchmarkPanel extends javax.swing.JPanel {
 
 
     public void addRun(Benchmark run) {
+        
+        List<BenchmarkOperation> operations = run.getOperations();
+        System.out.println("number of operations: " + operations.size());
         DefaultTableModel model = (DefaultTableModel) this.runTable.getModel();
-        model.addRow(
-                new Object[] {
-                    run.id,
-                    run.driveModel,
-                    run.getUsageColumnDisplay(),
-                    run.getModeDisplay(), 
-                    run.blockOrder,
-                    run.numSamples,
-                    run.getBlocksDisplay(),
-                    run.numThreads,
-                    run.getStartTimeString(),
-                    run.getDuration(),
-                    run.getAccTimeDisplay(),
-                    run.getBwMinMaxDisplay(),
-                    run.getBwAvgDisplay(),
-                });
+        for (BenchmarkOperation o : operations) {
+            model.addRow(
+                    new Object[] {
+                        run.id,
+                        run.driveModel,
+                        run.getUsageColumnDisplay(),
+                        o.getModeDisplay(),
+                        o.blockOrder,
+                        o.numSamples,
+                        o.getBlocksDisplay(),
+                        o.numThreads,
+                        o.getStartTimeString(),
+                        o.getDuration(),
+                        o.getAccTimeDisplay(),
+                        o.getBwMinMaxDisplay(),
+                        o.getBwAvgDisplay(),
+                    });
+        }
     }
     
     public void hideFirstColumn() {

--- a/src/jdiskmark/BenchmarkPanel.java
+++ b/src/jdiskmark/BenchmarkPanel.java
@@ -9,9 +9,6 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 
-/**
- * @author James
- */
 public class BenchmarkPanel extends javax.swing.JPanel {
 
     /**
@@ -23,6 +20,10 @@ public class BenchmarkPanel extends javax.swing.JPanel {
 
     // Tooltip only – keep it simple
     runTable.setToolTipText("Mode: Write* means Write Sync was enabled");
+    
+    // #73 load new selected operation
+    OperationTableSelectionListener selectionListener = new OperationTableSelectionListener(runTable);
+    runTable.getSelectionModel().addListSelectionListener(selectionListener);
 
     // center align cells 2 - 11
     for (int i = 2; i <= 11; i++) {
@@ -74,11 +75,6 @@ public class BenchmarkPanel extends javax.swing.JPanel {
             }
         });
         runTable.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        runTable.addMouseListener(new java.awt.event.MouseAdapter() {
-            public void mouseClicked(java.awt.event.MouseEvent evt) {
-                runTableMouseClicked(evt);
-            }
-        });
         jScrollPane1.setViewportView(runTable);
         if (runTable.getColumnModel().getColumnCount() > 0) {
             runTable.getColumnModel().getColumn(0).setPreferredWidth(10);
@@ -119,17 +115,6 @@ public class BenchmarkPanel extends javax.swing.JPanel {
     }// </editor-fold>//GEN-END:initComponents
 
     static final int START_TIME_COLUMN = 7;
-    
-    private void runTableMouseClicked(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_runTableMouseClicked
-        int sRow = runTable.getSelectedRow();
-        String timeString = (String) runTable.getValueAt(sRow, START_TIME_COLUMN);
-        System.out.println("selected operation starttime=" + timeString);
-        BenchmarkOperation operation = App.operations.get(timeString);
-        if (operation != null) {
-            Gui.loadOperation(operation);
-        }
-    }//GEN-LAST:event_runTableMouseClicked
-
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JScrollPane jScrollPane1;
@@ -140,7 +125,6 @@ public class BenchmarkPanel extends javax.swing.JPanel {
     public void addRun(Benchmark run) {
         
         List<BenchmarkOperation> operations = run.getOperations();
-        System.out.println("number of operations: " + operations.size());
         DefaultTableModel model = (DefaultTableModel) this.runTable.getModel();
         for (BenchmarkOperation o : operations) {
             model.addRow(

--- a/src/jdiskmark/BenchmarkWorker.java
+++ b/src/jdiskmark/BenchmarkWorker.java
@@ -108,31 +108,35 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
 
         List<java.util.concurrent.Future<?>> futures = new ArrayList<>();
 
+        Benchmark run = new Benchmark(App.benchmarkType);
+
+        // system info
+        run.processorName = App.processorName;
+        run.os = App.os;
+        run.arch = App.arch;
+        // drive information
+        run.driveModel = driveModel;
+        run.partitionId = partitionId;
+        run.percentUsed = usageInfo.percentUsed;
+        run.usedGb = usageInfo.usedGb;
+        run.totalGb = usageInfo.totalGb;        
+        
+        Gui.chart.getTitle().setText(run.getDriveInfo());
+        Gui.chart.getTitle().setVisible(true);
+        
         if (App.isWriteEnabled()) {
-            Benchmark run = new Benchmark(Benchmark.IOMode.WRITE, App.blockSequence);
-
-            // system info
-            run.processorName = App.processorName;
-            run.os = App.os;
-            run.arch = App.arch;
-            // drive information
-            run.driveModel = driveModel;
-            run.partitionId = partitionId;
-            run.percentUsed = usageInfo.percentUsed;
-            run.usedGb = usageInfo.usedGb;
-            run.totalGb = usageInfo.totalGb;
-            // benchmark parameters
-            run.numSamples = App.numOfSamples;
-            run.numBlocks = App.numOfBlocks;
-            run.blockSize = App.blockSizeKb;
-            run.txSize = App.targetTxSizeKb();
-            run.numThreads = App.numOfThreads;
-
+            BenchmarkOperation wOperation = new BenchmarkOperation();
+            wOperation.setBenchmark(run);
+            wOperation.ioMode = BenchmarkOperation.IOMode.WRITE;
+            wOperation.blockOrder = App.blockSequence;
+            wOperation.numSamples = App.numOfSamples;
+            wOperation.numBlocks = App.numOfSamples;
+            wOperation.blockSize = App.blockSizeKb;
+            wOperation.txSize = App.targetTxSizeKb();
+            wOperation.numThreads = App.numOfThreads;
             // persist whether write sync was enabled for this run
-            run.setWriteSyncEnabled(App.writeSyncEnable);
-
-            Gui.chart.getTitle().setText(run.getDriveInfo());
-            Gui.chart.getTitle().setVisible(true);
+            wOperation.setWriteSyncEnabled(App.writeSyncEnable);
+            run.getOperations().add(wOperation);
 
             if (App.multiFile == false) {
                 testFile = new File(dataDir.getAbsolutePath() + File.separator + "testdata.jdm");
@@ -161,7 +165,7 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
                         try {
                             try (RandomAccessFile rAccFile = new RandomAccessFile(testFile, mode)) {
                                 for (int b = 0; b < numOfBlocks; b++) {
-                                    if (App.blockSequence == Benchmark.BlockSequence.RANDOM) {
+                                    if (App.blockSequence == BenchmarkOperation.BlockSequence.RANDOM) {
                                         int rLoc = Util.randInt(0, numOfBlocks - 1);
                                         rAccFile.seek(rLoc * blockSize);
                                     } else {
@@ -186,17 +190,17 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
                         double sec = (double) elapsedTimeNs / 1_000_000_000d;
                         double mbWritten = (double) totalBytesWrittenInSample / (double) MEGABYTE;
                         sample.bwMbSec = mbWritten / sec;
-                        msg("s:" + s + " write IO is " + sample.getBwMbSecDisplay() + " MB/s   "
-                                + "(" + Util.displayString(mbWritten) + "MB written in "
-                                + Util.displayString(sec) + " sec) elapsedNs: " + elapsedTimeNs);
+//                        msg("s:" + s + " write IO is " + sample.getBwMbSecDisplay() + " MB/s   "
+//                                + "(" + Util.displayString(mbWritten) + "MB written in "
+//                                + Util.displayString(sec) + " sec) elapsedNs: " + elapsedTimeNs);
                         App.updateMetrics(sample);
                         publish(sample);
 
-                        run.bwMax = sample.cumMax;
-                        run.bwMin = sample.cumMin;
-                        run.bwAvg = sample.cumAvg;
-                        run.accAvg = sample.cumAccTimeMs;
-                        run.add(sample);
+                        wOperation.bwMax = sample.cumMax;
+                        wOperation.bwMin = sample.cumMin;
+                        wOperation.bwAvg = sample.cumAvg;
+                        wOperation.accAvg = sample.cumAccTimeMs;
+                        wOperation.add(sample);
                     }
                 }));
             }
@@ -205,17 +209,10 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
             executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
 
             // GH-10 file IOPS processing
-            run.endTime = LocalDateTime.now();
-            run.setTotalOps(wUnitsComplete[0]);
-            App.wIops = run.iops;
+            wOperation.endTime = LocalDateTime.now();
+            wOperation.setTotalOps(wUnitsComplete[0]);
+            App.wIops = wOperation.iops;
             Gui.mainFrame.refreshWriteMetrics();
-
-            EntityManager em = EM.getEntityManager();
-            em.getTransaction().begin();
-            em.persist(run);
-            em.getTransaction().commit();
-            App.benchmarks.put(run.getStartTimeString(), run);
-            Gui.runPanel.addRun(run);
         }
 
         // try renaming all files to clear catch
@@ -224,32 +221,19 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
         }
 
         if (App.isReadEnabled()) {
-            Benchmark run = new Benchmark(Benchmark.IOMode.READ, App.blockSequence);
-
-            // system info
-            run.processorName = App.processorName;
-            run.os = App.os;
-            run.arch = App.arch;
-
-            // drive information
-            run.driveModel = driveModel;
-            run.partitionId = partitionId;
-            run.percentUsed = usageInfo.percentUsed;
-            run.usedGb = usageInfo.usedGb;
-            run.totalGb = usageInfo.totalGb;
-
-            // benchmark parameters
-            run.numSamples = App.numOfSamples;
-            run.numBlocks = App.numOfBlocks;
-            run.blockSize = App.blockSizeKb;
-            run.txSize = App.targetTxSizeKb();
-            run.numThreads = App.numOfThreads;
-
+            BenchmarkOperation rOperation = new BenchmarkOperation();
+            rOperation.setBenchmark(run);
+            // operation parameters
+            rOperation.ioMode = BenchmarkOperation.IOMode.READ;
+            rOperation.blockOrder = App.blockSequence;
+            rOperation.numSamples = App.numOfSamples;
+            rOperation.numBlocks = App.numOfBlocks;
+            rOperation.blockSize = App.blockSizeKb;
+            rOperation.txSize = App.targetTxSizeKb();
+            rOperation.numThreads = App.numOfThreads;
             // write sync does not apply to pure read benchmarks
-            run.setWriteSyncEnabled(null);
-
-            Gui.chart.getTitle().setText(run.getDriveInfo());
-            Gui.chart.getTitle().setVisible(true);
+            rOperation.setWriteSyncEnabled(null);
+            run.getOperations().add(rOperation);
 
             ExecutorService executorService = Executors.newFixedThreadPool(App.numOfThreads);
 
@@ -271,7 +255,7 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
                         try {
                             try (RandomAccessFile rAccFile = new RandomAccessFile(testFile, "r")) {
                                 for (int b = 0; b < numOfBlocks; b++) {
-                                    if (App.blockSequence == Benchmark.BlockSequence.RANDOM) {
+                                    if (App.blockSequence == BenchmarkOperation.BlockSequence.RANDOM) {
                                         int rLoc = Util.randInt(0, numOfBlocks - 1);
                                         rAccFile.seek(rLoc * blockSize);
                                     } else {
@@ -296,18 +280,16 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
                         double sec = (double) elapsedTimeNs / 1_000_000_000d;
                         double mbRead = (double) totalBytesReadInMark / (double) MEGABYTE;
                         sample.bwMbSec = mbRead / sec;
-                        msg("s:" + s + " read IO is " + sample.getBwMbSecDisplay() + " MB/s   "
-                                + "(" + Util.displayString(mbRead) + "MB read in "
-                                + Util.displayString(sec) + " sec) elapsedNs: " + elapsedTimeNs);
+//                        msg("s:" + s + " read IO is " + sample.getBwMbSecDisplay() + " MB/s   "
+//                                + "(" + Util.displayString(mbRead) + "MB read in "
+//                                + Util.displayString(sec) + " sec) elapsedNs: " + elapsedTimeNs);
                         App.updateMetrics(sample);
                         publish(sample);
-
-                        run.bwMax = sample.cumMax;
-                        run.bwMin = sample.cumMin;
-                        run.bwAvg = sample.cumAvg;
-                        run.accAvg = sample.cumAccTimeMs;
-
-                        run.add(sample);
+                        rOperation.bwMax = sample.cumMax;
+                        rOperation.bwMin = sample.cumMin;
+                        rOperation.bwAvg = sample.cumAvg;
+                        rOperation.accAvg = sample.cumAccTimeMs;
+                        rOperation.add(sample);
                     }
                 }));
             }
@@ -316,18 +298,22 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
             executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
 
             // GH-10 file IOPS processing
-            run.endTime = LocalDateTime.now();
-            run.setTotalOps(rUnitsComplete[0]);
-            App.rIops = run.iops;
+            rOperation.endTime = LocalDateTime.now();
+            rOperation.setTotalOps(rUnitsComplete[0]);
+            App.rIops = rOperation.iops;
             Gui.mainFrame.refreshReadMetrics();
-
-            EntityManager em = EM.getEntityManager();
-            em.getTransaction().begin();
-            em.persist(run);
-            em.getTransaction().commit();
-            App.benchmarks.put(run.getStartTimeString(), run);
-            Gui.runPanel.addRun(run);
         }
+        run.endTime = LocalDateTime.now();
+        EntityManager em = EM.getEntityManager();
+        em.getTransaction().begin();
+        em.persist(run);
+        em.getTransaction().commit();
+        App.benchmarks.put(run.getStartTimeString(), run);
+        for (BenchmarkOperation o : run.getOperations()) {
+            App.operations.put(o.getStartTimeString(), o);
+        }
+        Gui.runPanel.addRun(run);
+        
         App.nextSampleNumber += App.numOfSamples;
         return true;
     }

--- a/src/jdiskmark/BenchmarkWorker.java
+++ b/src/jdiskmark/BenchmarkWorker.java
@@ -108,25 +108,25 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
 
         List<java.util.concurrent.Future<?>> futures = new ArrayList<>();
 
-        Benchmark run = new Benchmark(App.benchmarkType);
+        Benchmark benchmark = new Benchmark(App.benchmarkType);
 
         // system info
-        run.processorName = App.processorName;
-        run.os = App.os;
-        run.arch = App.arch;
+        benchmark.processorName = App.processorName;
+        benchmark.os = App.os;
+        benchmark.arch = App.arch;
         // drive information
-        run.driveModel = driveModel;
-        run.partitionId = partitionId;
-        run.percentUsed = usageInfo.percentUsed;
-        run.usedGb = usageInfo.usedGb;
-        run.totalGb = usageInfo.totalGb;        
+        benchmark.driveModel = driveModel;
+        benchmark.partitionId = partitionId;
+        benchmark.percentUsed = usageInfo.percentUsed;
+        benchmark.usedGb = usageInfo.usedGb;
+        benchmark.totalGb = usageInfo.totalGb;        
         
-        Gui.chart.getTitle().setText(run.getDriveInfo());
+        Gui.chart.getTitle().setText(benchmark.getDriveInfo());
         Gui.chart.getTitle().setVisible(true);
         
         if (App.isWriteEnabled()) {
             BenchmarkOperation wOperation = new BenchmarkOperation();
-            wOperation.setBenchmark(run);
+            wOperation.setBenchmark(benchmark);
             wOperation.ioMode = BenchmarkOperation.IOMode.WRITE;
             wOperation.blockOrder = App.blockSequence;
             wOperation.numSamples = App.numOfSamples;
@@ -136,7 +136,7 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
             wOperation.numThreads = App.numOfThreads;
             // persist whether write sync was enabled for this run
             wOperation.setWriteSyncEnabled(App.writeSyncEnable);
-            run.getOperations().add(wOperation);
+            benchmark.getOperations().add(wOperation);
 
             if (App.multiFile == false) {
                 testFile = new File(dataDir.getAbsolutePath() + File.separator + "testdata.jdm");
@@ -222,7 +222,7 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
 
         if (App.isReadEnabled()) {
             BenchmarkOperation rOperation = new BenchmarkOperation();
-            rOperation.setBenchmark(run);
+            rOperation.setBenchmark(benchmark);
             // operation parameters
             rOperation.ioMode = BenchmarkOperation.IOMode.READ;
             rOperation.blockOrder = App.blockSequence;
@@ -233,7 +233,7 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
             rOperation.numThreads = App.numOfThreads;
             // write sync does not apply to pure read benchmarks
             rOperation.setWriteSyncEnabled(null);
-            run.getOperations().add(rOperation);
+            benchmark.getOperations().add(rOperation);
 
             ExecutorService executorService = Executors.newFixedThreadPool(App.numOfThreads);
 
@@ -303,16 +303,16 @@ public class BenchmarkWorker extends SwingWorker<Boolean, Sample> {
             App.rIops = rOperation.iops;
             Gui.mainFrame.refreshReadMetrics();
         }
-        run.endTime = LocalDateTime.now();
+        benchmark.endTime = LocalDateTime.now();
         EntityManager em = EM.getEntityManager();
         em.getTransaction().begin();
-        em.persist(run);
+        em.persist(benchmark);
         em.getTransaction().commit();
-        App.benchmarks.put(run.getStartTimeString(), run);
-        for (BenchmarkOperation o : run.getOperations()) {
+        App.benchmarks.put(benchmark.getStartTimeString(), benchmark);
+        for (BenchmarkOperation o : benchmark.getOperations()) {
             App.operations.put(o.getStartTimeString(), o);
         }
-        Gui.runPanel.addRun(run);
+        Gui.runPanel.addRun(benchmark);
         
         App.nextSampleNumber += App.numOfSamples;
         return true;

--- a/src/jdiskmark/Gui.java
+++ b/src/jdiskmark/Gui.java
@@ -224,7 +224,7 @@ public final class Gui {
             wDrvAccess.add(s.sampleNum, s.accessTimeMs);
         }
         Gui.mainFrame.refreshWriteMetrics();
-        System.out.println(s.toString());
+        //System.out.println(s.toString());
     }
     public static void addReadSample(Sample s) {
         rSeries.add(s.sampleNum, s.bwMbSec);
@@ -237,7 +237,7 @@ public final class Gui {
             rDrvAccess.add(s.sampleNum, s.accessTimeMs);
         }
         Gui.mainFrame.refreshReadMetrics();
-        System.out.println(s.toString());
+        //System.out.println(s.toString());
     }
     
     public static void resetBenchmarkData() {
@@ -273,9 +273,9 @@ public final class Gui {
         msAxis.setVisible(App.showDriveAccess);
     }
     
-    public static void updateLegendAndAxis(Benchmark b) {
-        boolean isWriteTest = b.ioMode == Benchmark.IOMode.WRITE;
-        boolean isReadTest = b.ioMode == Benchmark.IOMode.READ;
+    public static void updateLegendAndAxis(BenchmarkOperation o) {
+        boolean isWriteTest = o.ioMode == BenchmarkOperation.IOMode.WRITE;
+        boolean isReadTest = o.ioMode == BenchmarkOperation.IOMode.READ;
         bwRenderer.setSeriesVisibleInLegend(0, isWriteTest);
         bwRenderer.setSeriesVisibleInLegend(1, isWriteTest);
         bwRenderer.setSeriesVisibleInLegend(2, isWriteTest && App.showMaxMin);
@@ -400,41 +400,43 @@ public final class Gui {
         }
     }
     
-    static public void loadBenchmark(Benchmark benchmark) {
+    static public void loadOperation(BenchmarkOperation operation) {        
+        Benchmark benchmark = operation.getBenchmark();
+        System.out.println("benchmark type: " + benchmark.benchmarkType + " o: " + operation.ioMode);
         resetBenchmarkData();
-        updateLegendAndAxis(benchmark);
+        updateLegendAndAxis(operation);
         chart.getTitle().setText(benchmark.getDriveInfo());
-        ArrayList<Sample> samples = benchmark.samples;
+        ArrayList<Sample> samples = operation.getSamples();
         System.out.println("samples=" + samples.size());
         for (Sample s : samples) {
-            System.out.println(s);
-            if (benchmark.ioMode == Benchmark.IOMode.READ) {
+            if (operation.ioMode == BenchmarkOperation.IOMode.READ) {
                 addReadSample(s);
             } else {
                 addWriteSample(s);
             }
         }
-        
-        App.numOfBlocks = benchmark.numBlocks;
-        App.numOfSamples = benchmark.numSamples;
-        App.blockSizeKb = benchmark.blockSize;
-        App.blockSequence = benchmark.blockOrder;
+        App.numOfBlocks = operation.numBlocks;
+        App.numOfSamples = operation.numSamples;
+        App.blockSizeKb = operation.blockSize;
+        App.blockSequence = operation.blockOrder;
         Gui.mainFrame.loadSettings();
-        
-        if (benchmark.ioMode ==  Benchmark.IOMode.READ) {
-            App.rAvg = benchmark.bwAvg;
-            App.rMax = benchmark.bwMax;
-            App.rMin = benchmark.bwMin;
-            App.rAcc = benchmark.accAvg;
-            App.rIops = benchmark.iops;
-            Gui.mainFrame.refreshReadMetrics();
-        } else {
-            App.wAvg = benchmark.bwAvg;
-            App.wMax = benchmark.bwMax;
-            App.wMin = benchmark.bwMin;
-            App.wAcc = benchmark.accAvg;
-            App.wIops = benchmark.iops;
-            Gui.mainFrame.refreshWriteMetrics();
+        switch (operation.ioMode) {
+            case BenchmarkOperation.IOMode.READ -> {
+                App.rAvg = operation.bwAvg;
+                App.rMax = operation.bwMax;
+                App.rMin = operation.bwMin;
+                App.rAcc = operation.accAvg;
+                App.rIops = operation.iops;
+                Gui.mainFrame.refreshReadMetrics();                
+            }
+            case BenchmarkOperation.IOMode.WRITE -> {
+                App.wAvg = operation.bwAvg;
+                App.wMax = operation.bwMax;
+                App.wMin = operation.bwMin;
+                App.wAcc = operation.accAvg;
+                App.wIops = operation.iops;
+                Gui.mainFrame.refreshWriteMetrics();
+            }
         }
     }
 

--- a/src/jdiskmark/Gui.java
+++ b/src/jdiskmark/Gui.java
@@ -415,10 +415,12 @@ public final class Gui {
                 addWriteSample(s);
             }
         }
+        App.benchmarkType = benchmark.benchmarkType;
         App.numOfBlocks = operation.numBlocks;
         App.numOfSamples = operation.numSamples;
         App.blockSizeKb = operation.blockSize;
         App.blockSequence = operation.blockOrder;
+        App.numOfThreads = operation.numThreads;
         Gui.mainFrame.loadSettings();
         switch (operation.ioMode) {
             case BenchmarkOperation.IOMode.READ -> {

--- a/src/jdiskmark/MainFrame.form
+++ b/src/jdiskmark/MainFrame.form
@@ -278,8 +278,8 @@
         <Component class="jdiskmark.BenchmarkPanel" name="runPanel">
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
-              <JTabbedPaneConstraints tabName="Benchmarks">
-                <Property name="tabTitle" type="java.lang.String" value="Benchmarks"/>
+              <JTabbedPaneConstraints tabName="Benchmark Operations">
+                <Property name="tabTitle" type="java.lang.String" value="Benchmark Operations"/>
               </JTabbedPaneConstraints>
             </Constraint>
           </Constraints>
@@ -454,12 +454,12 @@
                                   </Group>
                                   <EmptySpace min="-2" pref="18" max="-2" attributes="0"/>
                                   <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                                      <Component id="modeCombo" alignment="0" max="32767" attributes="0"/>
+                                      <Component id="typeCombo" alignment="0" max="32767" attributes="0"/>
                                       <Component id="numThreadsCombo" alignment="0" pref="100" max="32767" attributes="0"/>
                                       <Component id="orderComboBox" alignment="0" max="32767" attributes="0"/>
                                       <Component id="numBlocksCombo" alignment="0" max="32767" attributes="0"/>
                                       <Component id="blockSizeCombo" alignment="0" max="32767" attributes="0"/>
-                                      <Component id="numFilesCombo" alignment="0" max="32767" attributes="0"/>
+                                      <Component id="numSamplesCombo" alignment="0" max="32767" attributes="0"/>
                                   </Group>
                               </Group>
                               <Group type="102" alignment="0" attributes="0">
@@ -534,7 +534,7 @@
               <Group type="102" alignment="0" attributes="0">
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="jLabel4" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="modeCombo" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="typeCombo" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
@@ -559,7 +559,7 @@
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="jLabel8" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="numFilesCombo" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="numSamplesCombo" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
@@ -567,7 +567,7 @@
                       <Component id="sampleSizeLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
-                  <Component id="startButton" pref="43" max="32767" attributes="0"/>
+                  <Component id="startButton" max="32767" attributes="0"/>
                   <EmptySpace type="separate" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Component id="jLabel20" alignment="1" min="-2" max="-2" attributes="0"/>
@@ -698,7 +698,7 @@
             <Property name="text" type="java.lang.String" value="No. Samples"/>
           </Properties>
         </Component>
-        <Component class="javax.swing.JComboBox" name="numFilesCombo">
+        <Component class="javax.swing.JComboBox" name="numSamplesCombo">
           <Properties>
             <Property name="editable" type="boolean" value="true"/>
             <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
@@ -721,15 +721,15 @@
             </Property>
           </Properties>
           <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="numFilesComboActionPerformed"/>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="numSamplesComboActionPerformed"/>
           </Events>
         </Component>
         <Component class="javax.swing.JLabel" name="jLabel4">
           <Properties>
-            <Property name="text" type="java.lang.String" value="IO Mode"/>
+            <Property name="text" type="java.lang.String" value="Benchmark Type"/>
           </Properties>
         </Component>
-        <Component class="javax.swing.JComboBox" name="modeCombo">
+        <Component class="javax.swing.JComboBox" name="typeCombo">
           <Properties>
             <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
               <StringArray count="2">
@@ -742,7 +742,7 @@
             </Property>
           </Properties>
           <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="modeComboActionPerformed"/>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="typeComboActionPerformed"/>
           </Events>
         </Component>
         <Component class="javax.swing.JLabel" name="jLabel9">
@@ -771,7 +771,7 @@
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="orderComboBoxActionPerformed"/>
           </Events>
           <AuxValues>
-            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;Benchmark.BlockSequence&gt;"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;BenchmarkOperation.BlockSequence&gt;"/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JLabel" name="jLabel14">

--- a/src/jdiskmark/MainFrame.java
+++ b/src/jdiskmark/MainFrame.java
@@ -122,6 +122,7 @@ public final class MainFrame extends javax.swing.JFrame {
 }
 
     public void loadSettings() {
+        typeCombo.setSelectedItem(App.benchmarkType);
         numThreadsCombo.setSelectedItem(String.valueOf(App.numOfThreads));
         orderComboBox.setSelectedItem(App.blockSequence);
         numBlocksCombo.setSelectedItem(String.valueOf(App.numOfBlocks));

--- a/src/jdiskmark/MainFrame.java
+++ b/src/jdiskmark/MainFrame.java
@@ -33,9 +33,9 @@ public final class MainFrame extends javax.swing.JFrame {
         //for diagnostics
         //controlsPanel.setBackground(Color.blue);
         
-        DefaultComboBoxModel<Benchmark.IOMode> ioModel
-                = new DefaultComboBoxModel<>(Benchmark.IOMode.values());
-        modeCombo.setModel(ioModel);
+        DefaultComboBoxModel<Benchmark.BenchmarkType> ioModel
+                = new DefaultComboBoxModel<>(Benchmark.BenchmarkType.values());
+        typeCombo.setModel(ioModel);
 
         startButton.requestFocus();
         Gui.createChartPanel();
@@ -73,8 +73,8 @@ public final class MainFrame extends javax.swing.JFrame {
         caret.setUpdatePolicy(DefaultCaret.ALWAYS_UPDATE);
         
         // init order combo box
-        orderComboBox.addItem(Benchmark.BlockSequence.SEQUENTIAL);
-        orderComboBox.addItem(Benchmark.BlockSequence.RANDOM);
+        orderComboBox.addItem(BenchmarkOperation.BlockSequence.SEQUENTIAL);
+        orderComboBox.addItem(BenchmarkOperation.BlockSequence.RANDOM);
     }
 
     public JPanel getMountPanel() {
@@ -117,17 +117,16 @@ public final class MainFrame extends javax.swing.JFrame {
     }
 
     public void initializeComboSettings() {
-    modeCombo.setSelectedItem(App.ioMode);
+    typeCombo.setSelectedItem(App.benchmarkType);
     loadSettings();
 }
 
     public void loadSettings() {
-        //String blockOrderStr = App.randomEnable ? "random":"sequential";
+        numThreadsCombo.setSelectedItem(String.valueOf(App.numOfThreads));
         orderComboBox.setSelectedItem(App.blockSequence);
-        
-        numFilesCombo.setSelectedItem(String.valueOf(App.numOfSamples));
         numBlocksCombo.setSelectedItem(String.valueOf(App.numOfBlocks));
-        blockSizeCombo.setSelectedItem(String.valueOf(App.blockSizeKb)); 
+        blockSizeCombo.setSelectedItem(String.valueOf(App.blockSizeKb));
+        numSamplesCombo.setSelectedItem(String.valueOf(App.numOfSamples));
     }
     
     
@@ -158,9 +157,9 @@ public final class MainFrame extends javax.swing.JFrame {
         jLabel6 = new javax.swing.JLabel();
         blockSizeCombo = new javax.swing.JComboBox();
         jLabel8 = new javax.swing.JLabel();
-        numFilesCombo = new javax.swing.JComboBox();
+        numSamplesCombo = new javax.swing.JComboBox();
         jLabel4 = new javax.swing.JLabel();
-        modeCombo = new javax.swing.JComboBox();
+        typeCombo = new javax.swing.JComboBox();
         jLabel9 = new javax.swing.JLabel();
         sampleSizeLabel = new javax.swing.JLabel();
         orderComboBox = new javax.swing.JComboBox<>();
@@ -223,7 +222,7 @@ public final class MainFrame extends javax.swing.JFrame {
         setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
         setTitle("JDiskMark");
 
-        tabbedPane.addTab("Benchmarks", runPanel);
+        tabbedPane.addTab("Benchmark Operations", runPanel);
 
         msgTextArea.setEditable(false);
         msgTextArea.setColumns(20);
@@ -330,23 +329,23 @@ public final class MainFrame extends javax.swing.JFrame {
 
         jLabel8.setText("No. Samples");
 
-        numFilesCombo.setEditable(true);
-        numFilesCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "50", "100", "200", "300", "500", "1000", "2000", "3000", "5000", "10000" }));
-        numFilesCombo.setSelectedIndex(2);
-        numFilesCombo.setPreferredSize(new java.awt.Dimension(72, 24));
-        numFilesCombo.addActionListener(new java.awt.event.ActionListener() {
+        numSamplesCombo.setEditable(true);
+        numSamplesCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "50", "100", "200", "300", "500", "1000", "2000", "3000", "5000", "10000" }));
+        numSamplesCombo.setSelectedIndex(2);
+        numSamplesCombo.setPreferredSize(new java.awt.Dimension(72, 24));
+        numSamplesCombo.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
-                numFilesComboActionPerformed(evt);
+                numSamplesComboActionPerformed(evt);
             }
         });
 
-        jLabel4.setText("IO Mode");
+        jLabel4.setText("Benchmark Type");
 
-        modeCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { " ", " " }));
-        modeCombo.setPreferredSize(new java.awt.Dimension(60, 24));
-        modeCombo.addActionListener(new java.awt.event.ActionListener() {
+        typeCombo.setModel(new javax.swing.DefaultComboBoxModel(new String[] { " ", " " }));
+        typeCombo.setPreferredSize(new java.awt.Dimension(60, 24));
+        typeCombo.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
-                modeComboActionPerformed(evt);
+                typeComboActionPerformed(evt);
             }
         });
 
@@ -452,12 +451,12 @@ public final class MainFrame extends javax.swing.JFrame {
                                     .addComponent(jLabel21))
                                 .addGap(18, 18, 18)
                                 .addGroup(controlsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                                    .addComponent(modeCombo, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                    .addComponent(typeCombo, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                                     .addComponent(numThreadsCombo, 0, 100, Short.MAX_VALUE)
                                     .addComponent(orderComboBox, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                                     .addComponent(numBlocksCombo, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                                     .addComponent(blockSizeCombo, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                    .addComponent(numFilesCombo, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
+                                    .addComponent(numSamplesCombo, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
                             .addGroup(controlsPanelLayout.createSequentialGroup()
                                 .addGroup(controlsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                                     .addComponent(jLabel13)
@@ -510,7 +509,7 @@ public final class MainFrame extends javax.swing.JFrame {
             .addGroup(controlsPanelLayout.createSequentialGroup()
                 .addGroup(controlsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel4)
-                    .addComponent(modeCombo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addComponent(typeCombo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(controlsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(numThreadsCombo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -530,13 +529,13 @@ public final class MainFrame extends javax.swing.JFrame {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(controlsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel8)
-                    .addComponent(numFilesCombo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addComponent(numSamplesCombo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(controlsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel9)
                     .addComponent(sampleSizeLabel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(startButton, javax.swing.GroupLayout.DEFAULT_SIZE, 43, Short.MAX_VALUE)
+                .addComponent(startButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGap(18, 18, 18)
                 .addGroup(controlsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(jLabel20, javax.swing.GroupLayout.Alignment.TRAILING)
@@ -833,6 +832,7 @@ public final class MainFrame extends javax.swing.JFrame {
     }//GEN-LAST:event_startButtonActionPerformed
 
     private void blockSizeComboActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_blockSizeComboActionPerformed
+        // NOTE: selecting a value from dropdown does not trigger the below
         if (blockSizeCombo.hasFocus()) {
             App.blockSizeKb = Integer.parseInt((String) blockSizeCombo.getSelectedItem());
             sampleSizeLabel.setText(String.valueOf(App.targetMarkSizeKb()));
@@ -842,6 +842,7 @@ public final class MainFrame extends javax.swing.JFrame {
     }//GEN-LAST:event_blockSizeComboActionPerformed
 
     private void numBlocksComboActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_numBlocksComboActionPerformed
+        // NOTE: selecting a value from dropdown does not trigger the below
         if (numBlocksCombo.hasFocus()) {
             App.numOfBlocks = Integer.parseInt((String) numBlocksCombo.getSelectedItem());
             sampleSizeLabel.setText(String.valueOf(App.targetMarkSizeKb()));
@@ -850,23 +851,23 @@ public final class MainFrame extends javax.swing.JFrame {
         }
     }//GEN-LAST:event_numBlocksComboActionPerformed
 
-    private void numFilesComboActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_numFilesComboActionPerformed
-        if (numFilesCombo.hasFocus()) {
-            App.numOfSamples = Integer.parseInt((String) numFilesCombo.getSelectedItem());
+    private void numSamplesComboActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_numSamplesComboActionPerformed
+        // NOTE: selecting a value from dropdown does not trigger the below
+        if (numSamplesCombo.hasFocus()) {
+            App.numOfSamples = Integer.parseInt((String) numSamplesCombo.getSelectedItem());
             sampleSizeLabel.setText(String.valueOf(App.targetMarkSizeKb()));
             totalTxProgBar.setString(String.valueOf(App.targetTxSizeKb()));
             App.saveConfig();
         }
-    }//GEN-LAST:event_numFilesComboActionPerformed
+    }//GEN-LAST:event_numSamplesComboActionPerformed
 
-    private void modeComboActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_modeComboActionPerformed
-        if (modeCombo.hasFocus()) {
-            Benchmark.IOMode mode = (Benchmark.IOMode) modeCombo.getSelectedItem();
-            App.ioMode = mode;
+    private void typeComboActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_typeComboActionPerformed
+        if (typeCombo.hasFocus()) {
+            Benchmark.BenchmarkType mode = (Benchmark.BenchmarkType) typeCombo.getSelectedItem();
+            App.benchmarkType = mode;
             App.saveConfig();
-            System.out.println("modeCombo changed to: " + mode);
         }
-    }//GEN-LAST:event_modeComboActionPerformed
+    }//GEN-LAST:event_typeComboActionPerformed
 
     private void exitMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_exitMenuItemActionPerformed
         System.exit(0);
@@ -919,7 +920,7 @@ public final class MainFrame extends javax.swing.JFrame {
 
     private void orderComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_orderComboBoxActionPerformed
         if (orderComboBox.hasFocus()) {
-            App.blockSequence = (Benchmark.BlockSequence) orderComboBox.getSelectedItem();
+            App.blockSequence = (BenchmarkOperation.BlockSequence) orderComboBox.getSelectedItem();
             App.saveConfig();
         }
     }//GEN-LAST:event_orderComboBoxActionPerformed
@@ -986,6 +987,7 @@ public final class MainFrame extends javax.swing.JFrame {
     }//GEN-LAST:event_resetBenchmarkItemActionPerformed
 
     private void numThreadsComboActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_numThreadsComboActionPerformed
+        // NOTE: selecting a value from dropdown does not trigger the below
         if (numThreadsCombo.hasFocus()) {
             App.numOfThreads = Integer.parseInt((String) numThreadsCombo.getSelectedItem());
             App.saveConfig();
@@ -1041,16 +1043,15 @@ public final class MainFrame extends javax.swing.JFrame {
     private javax.swing.JPanel locationPanel;
     private javax.swing.JTextField locationText;
     private javax.swing.JMenuBar menuBar;
-    private javax.swing.JComboBox modeCombo;
     private javax.swing.JPanel mountPanel;
     private javax.swing.JTextArea msgTextArea;
     private javax.swing.JCheckBoxMenuItem multiFileCheckBoxMenuItem;
     private javax.swing.JComboBox numBlocksCombo;
-    private javax.swing.JComboBox numFilesCombo;
+    private javax.swing.JComboBox numSamplesCombo;
     private javax.swing.JComboBox numThreadsCombo;
     private javax.swing.JButton openLocButton;
     private javax.swing.JMenu optionMenu;
-    private javax.swing.JComboBox<Benchmark.BlockSequence> orderComboBox;
+    private javax.swing.JComboBox<BenchmarkOperation.BlockSequence> orderComboBox;
     private javax.swing.ButtonGroup palettebuttonGroup;
     private javax.swing.JPanel progressPanel;
     private javax.swing.JLabel rAccessLabel;
@@ -1067,6 +1068,7 @@ public final class MainFrame extends javax.swing.JFrame {
     private javax.swing.JButton startButton;
     private javax.swing.JTabbedPane tabbedPane;
     private javax.swing.JProgressBar totalTxProgBar;
+    private javax.swing.JComboBox typeCombo;
     private javax.swing.JLabel wAccessLabel;
     private javax.swing.JLabel wAvgLabel;
     private javax.swing.JLabel wIopsLabel;
@@ -1084,10 +1086,10 @@ public final class MainFrame extends javax.swing.JFrame {
     }
   
     public void applyTestParams() {
-        Benchmark.IOMode mode = (Benchmark.IOMode) modeCombo.getSelectedItem();
-        App.ioMode = mode;
-        App.blockSequence = (Benchmark.BlockSequence) orderComboBox.getSelectedItem();
-        App.numOfSamples = Integer.parseInt((String) numFilesCombo.getSelectedItem());
+        Benchmark.BenchmarkType mode = (Benchmark.BenchmarkType) typeCombo.getSelectedItem();
+        App.benchmarkType = mode;
+        App.blockSequence = (BenchmarkOperation.BlockSequence) orderComboBox.getSelectedItem();
+        App.numOfSamples = Integer.parseInt((String) numSamplesCombo.getSelectedItem());
         App.numOfBlocks = Integer.parseInt((String) numBlocksCombo.getSelectedItem());
         App.blockSizeKb = Integer.parseInt((String) blockSizeCombo.getSelectedItem());
         App.numOfThreads = Integer.parseInt((String) numThreadsCombo.getSelectedItem());
@@ -1138,8 +1140,8 @@ public final class MainFrame extends javax.swing.JFrame {
                 orderComboBox.setEnabled(false);
                 blockSizeCombo.setEnabled(false);
                 numBlocksCombo.setEnabled(false);
-                numFilesCombo.setEnabled(false);
-                modeCombo.setEnabled(false);
+                numSamplesCombo.setEnabled(false);
+                typeCombo.setEnabled(false);
                 numThreadsCombo.setEnabled(false);
                 resetBenchmarkItem.setEnabled(false);
             }
@@ -1148,20 +1150,23 @@ public final class MainFrame extends javax.swing.JFrame {
                 orderComboBox.setEnabled(true);
                 blockSizeCombo.setEnabled(true);
                 numBlocksCombo.setEnabled(true);
-                numFilesCombo.setEnabled(true);
-                modeCombo.setEnabled(true);
+                numSamplesCombo.setEnabled(true);
+                typeCombo.setEnabled(true);
                 numThreadsCombo.setEnabled(true);
                 resetBenchmarkItem.setEnabled(true);
             }
+
+
+
         }
     }   
     // Replace lowercase mode options with proper casing
 
 @SuppressWarnings("unchecked")
 private void configureModeCombo() {
-    modeCombo.removeAllItems();
-    modeCombo.addItem("Write");
-    modeCombo.addItem("Read");
-    modeCombo.addItem("Read & Write");
+    typeCombo.removeAllItems();
+    typeCombo.addItem("Write");
+    typeCombo.addItem("Read");
+    typeCombo.addItem("Read & Write");
 }    
 }

--- a/src/jdiskmark/MainFrame.java
+++ b/src/jdiskmark/MainFrame.java
@@ -117,9 +117,9 @@ public final class MainFrame extends javax.swing.JFrame {
     }
 
     public void initializeComboSettings() {
-    typeCombo.setSelectedItem(App.benchmarkType);
-    loadSettings();
-}
+        typeCombo.setSelectedItem(App.benchmarkType);
+        loadSettings();
+    }
 
     public void loadSettings() {
         typeCombo.setSelectedItem(App.benchmarkType);
@@ -129,7 +129,6 @@ public final class MainFrame extends javax.swing.JFrame {
         blockSizeCombo.setSelectedItem(String.valueOf(App.blockSizeKb));
         numSamplesCombo.setSelectedItem(String.valueOf(App.numOfSamples));
     }
-    
     
     /**
      * This method is called from within the constructor to initialize the form.
@@ -1156,18 +1155,15 @@ public final class MainFrame extends javax.swing.JFrame {
                 numThreadsCombo.setEnabled(true);
                 resetBenchmarkItem.setEnabled(true);
             }
-
-
-
         }
     }   
     // Replace lowercase mode options with proper casing
 
-@SuppressWarnings("unchecked")
-private void configureModeCombo() {
-    typeCombo.removeAllItems();
-    typeCombo.addItem("Write");
-    typeCombo.addItem("Read");
-    typeCombo.addItem("Read & Write");
-}    
+    @SuppressWarnings("unchecked")
+    private void configureModeCombo() {
+        typeCombo.removeAllItems();
+        typeCombo.addItem("Write");
+        typeCombo.addItem("Read");
+        typeCombo.addItem("Read & Write");
+    }    
 }

--- a/src/jdiskmark/OperationTableSelectionListener.java
+++ b/src/jdiskmark/OperationTableSelectionListener.java
@@ -1,0 +1,33 @@
+
+package jdiskmark;
+
+import javax.swing.JTable;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import static jdiskmark.BenchmarkPanel.START_TIME_COLUMN;
+
+public class OperationTableSelectionListener implements ListSelectionListener {
+    final private JTable table;
+
+    public OperationTableSelectionListener(JTable table) {
+        this.table = table;
+    }
+
+    @Override
+    public void valueChanged(ListSelectionEvent e) {
+        // This prevents the event from firing twice (once for the old selection, once for the new)
+        if (e.getValueIsAdjusting()) {
+            return;
+        }
+        
+        int selectedRow = table.getSelectedRow();
+        if (selectedRow != -1) {
+            String timeString = (String) table.getValueAt(selectedRow, START_TIME_COLUMN);
+            System.out.println("selected operation starttime=" + timeString);
+            BenchmarkOperation operation = App.operations.get(timeString);
+            if (operation != null) {
+                Gui.loadOperation(operation);
+            }
+        }
+    }
+}


### PR DESCRIPTION
summary of changes:
1. refactored benchmark data model to separate benchmark from operation
    - jpa references updated, cascade all
    - Parent class is Benchmark, BenchmarkOperation is the child class
    - allows more complex modeling like crystal disk mark models
2. keyboard can now be used to select a new record in the benchmark operation history will automatically load the record
3. Benchmark tab renamed to Benchmark Operations
4. introduced benchmark type which translates to IOMode at the operation level
5. fixed updating of num threads and Benchmark Type on load

