### PR TITLE
modern io engine w sector alignment

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -77,7 +77,7 @@
     <property name="build.dir" value="build"/>
 
     <!-- dependencies -->
-    <property name="jpackage.executable" value="C:\Program Files\java\jdk-21\bin\jpackage"/>
+    <property name="jpackage.executable" value="C:\Program Files\java\jdk-25\bin\jpackage"/>
     <property name="signtool.executable" value="C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x86\signtool.exe"/>
 
     <!-- version properties -->
@@ -306,7 +306,7 @@ Version: ${deb.version}
 Section: utils
 Priority: optional
 Architecture: all
-Depends: default-jre | openjdk-21-jre | openjdk-17-jre
+Depends: openjdk-25-jre
 Maintainer: JDiskMark Team
 Description: JDiskMark - Disk Benchmark Utility
  JDiskMark is a cross-platform disk benchmark utility written in Java.
@@ -342,7 +342,7 @@ Categories=Utility;System;</echo>
     </target>
     
     <target name="create-fat-deb" depends="clean, -pre-jar, jar, -post-jar"
-            description="Create a self-contained DEB with JRE 21">
+            description="Create a self-contained DEB">
         
         <condition property="is.linux">
             <os family="unix" />
@@ -397,7 +397,7 @@ Categories=Utility;System;</echo>
     
     <!-- depends="jar, -post-jar" -->
     <target name="create-fat-rpm" depends="clean, jar, -post-jar"
-            description="Create a self-contained RPM with JRE 21">
+            description="Create a self-contained RPM">
         
         <condition property="is.linux">
             <os family="unix" />

--- a/build.xml
+++ b/build.xml
@@ -83,7 +83,7 @@
     <!-- version properties -->
     <property name="pkg.name" value="jdiskmark"/>
     <property name="app.name" value="JDiskMark"/>
-    <property name="version" value="0.6.3-dev.fat"/>
+    <property name="version" value="0.6.3-dev.align"/>
     <!-- full semver does not work for msi product versions -->
     <property name="msi.version" value="0.6.3"/>
     <property name="msi.app.title" value="${app.name} ${version}"/>
@@ -341,7 +341,7 @@ Categories=Utility;System;</echo>
         <echo message="Package created: jdiskmark_${deb.version}_all.deb"/>
     </target>
     
-    <target name="create-fat-deb" depends="clean, jar, -post-jar"
+    <target name="create-fat-deb" depends="clean, -pre-jar, jar, -post-jar"
             description="Create a self-contained DEB with JRE 21">
         
         <condition property="is.linux">

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -72,8 +72,8 @@ javac.modulepath=
 javac.processormodulepath=
 javac.processorpath=\
     ${javac.classpath}
-javac.source=21
-javac.target=21
+javac.source=25
+javac.target=25
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -65,7 +65,7 @@ javac.classpath=\
     ${file.reference.flatlaf-3.3.jar}:\
     ${file.reference.jackson-datatype-jsr310-2.16.1.jar}
 # Space-separated list of extra javac options
-javac.compilerargs=-Xlint:unchecked -Xlint:deprecation
+javac.compilerargs=-Xlint:unchecked -Xlint:deprecation -XDignore.symbol.file
 javac.deprecation=false
 javac.external.vm=false
 javac.modulepath=

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -258,6 +258,9 @@ public class App {
         // configure settings from properties
         String value;
 
+        value = p.getProperty("activeProfile", activeProfile.name());
+        activeProfile = BenchmarkProfile.valueOf(value.toUpperCase());
+        
         value = p.getProperty("benchmarkType", String.valueOf(benchmarkType));
         benchmarkType = BenchmarkType.valueOf(value.toUpperCase());
         
@@ -308,6 +311,7 @@ public class App {
         if (p == null) { p = new Properties(); }
         
         // configure properties
+        p.setProperty("activeProfile", activeProfile.name());
         p.setProperty("benchmarkType", benchmarkType.name());
         p.setProperty("multiFile", String.valueOf(multiFile));
         p.setProperty("autoRemoveData", String.valueOf(autoRemoveData));

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -318,7 +318,15 @@ public class App {
         numOfThreads = Integer.parseInt(value);
 
         value = p.getProperty("ioEngine", ioEngine.name());
-        ioEngine = IoEngine.valueOf(value.toUpperCase());
+        try {
+            ioEngine = IoEngine.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            Logger.getLogger(App.class.getName()).log(
+                    Level.WARNING,
+                    "Invalid ioEngine value in properties: " + value + ", using default: " + ioEngine.name(),
+                    ex
+            );
+        }
         
         value = p.getProperty("writeSyncEnable", String.valueOf(writeSyncEnable));
         writeSyncEnable = Boolean.parseBoolean(value);

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -282,7 +282,16 @@ public class App {
         String value;
 
         value = p.getProperty("activeProfile", activeProfile.name());
-        activeProfile = BenchmarkProfile.valueOf(value.toUpperCase());
+        BenchmarkProfile previousActiveProfile = activeProfile;
+        try {
+            activeProfile = BenchmarkProfile.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            Logger.getLogger(App.class.getName()).log(
+                    Level.WARNING,
+                    "Invalid activeProfile value in properties file: \"{0}\". Falling back to default: {1}",
+                    new Object[]{value, previousActiveProfile.name()});
+            activeProfile = previousActiveProfile;
+        }
         
         value = p.getProperty("benchmarkType", String.valueOf(benchmarkType));
         benchmarkType = BenchmarkType.valueOf(value.toUpperCase());

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -438,7 +438,15 @@ public class App {
             case CLI -> System.out.println(message);
         }
     }
-    
+    public static void err(String message) {
+        switch(mode) {
+            case GUI -> {
+                Gui.mainFrame.msg(message);
+                System.err.println(message);
+            }
+            case CLI -> System.err.println(message);
+        }
+    }
     public static void cancelBenchmark() {
         if (worker == null) { 
             msg("worker is null abort..."); 

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -1,6 +1,10 @@
 
 package jdiskmark;
 
+import static jdiskmark.Benchmark.BenchmarkType;
+import static jdiskmark.Benchmark.BlockSequence;
+import static jdiskmark.DriveAccessChecker.validateTargetDirectory;
+
 import picocli.CommandLine;
 import java.io.File;
 import java.io.FileInputStream;
@@ -22,10 +26,6 @@ import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.SwingWorker.StateValue;
-import static jdiskmark.Benchmark.BenchmarkType;
-import static jdiskmark.Benchmark.BlockSequence;
-import static jdiskmark.Benchmark.IOMode;
-import static jdiskmark.DriveAccessChecker.validateTargetDirectory;
 
 /**
  * Primary class for global variables.
@@ -53,12 +53,21 @@ public class App {
     // app is in command line or graphical mode
     public enum Mode { CLI, GUI }
     public static Mode mode = Mode.CLI;
+    // io api, modern introduced w jdk 25 lts
+    public enum IoEngine {
+        MODERN("Modern (FFM API)"),
+        LEGACY("Legacy (RandomAccessFile)");
+        private final String label;
+        IoEngine(String label) { this.label = label; }
+        @Override public String toString() { return label; }
+    }
+    public static IoEngine ioEngine = IoEngine.MODERN;
     // member
     public static Properties p;
     public static File locationDir = null;
     public static File exportPath = null;
     public static File dataDir = null; // refactor to dataPath after all branches merged
-    public static File testFile = null;
+    public static File testFile = null; // still used for cli
     // system info
     public static String os;
     public static String arch;
@@ -75,11 +84,11 @@ public class App {
     public static boolean autoReset = true;
     public static boolean showMaxMin = true;
     public static boolean showDriveAccess = true;
+    public static boolean directEnable = false;
     public static boolean writeSyncEnable = false;
     // benchmark configuration
     public static BenchmarkProfile activeProfile = BenchmarkProfile.QUICK_TEST;
     public static BenchmarkType benchmarkType = BenchmarkType.WRITE;
-    public static IOMode ioMode = IOMode.WRITE;
     public static BlockSequence blockSequence = BlockSequence.SEQUENTIAL;
     public static int numOfSamples = 200;   // desired number of samples
     public static int numOfBlocks = 32;     // desired number of blocks

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -335,7 +335,15 @@ public class App {
         directEnable = Boolean.parseBoolean(value);
         
         value = p.getProperty("sectorAlignment", sectorAlignment.name());
-        sectorAlignment = SectorAlignment.valueOf(value.toUpperCase());
+        try {
+            sectorAlignment = SectorAlignment.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            Logger.getLogger(App.class.getName()).log(
+                    Level.WARNING,
+                    "Invalid sectorAlignment value in properties: \"{0}\", using default: {1}",
+                    new Object[] { value, sectorAlignment.name() }
+            );
+        }
 
         value = p.getProperty("palette", String.valueOf(Gui.palette));
         Gui.palette = Gui.Palette.valueOf(value);

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -291,8 +291,14 @@ public class App {
         value = p.getProperty("numOfThreads", String.valueOf(numOfThreads));
         numOfThreads = Integer.parseInt(value);
 
+        value = p.getProperty("ioEngine", ioEngine.name());
+        ioEngine = IoEngine.valueOf(value.toUpperCase());
+        
         value = p.getProperty("writeSyncEnable", String.valueOf(writeSyncEnable));
         writeSyncEnable = Boolean.parseBoolean(value);
+        
+        value = p.getProperty("directEnable", String.valueOf(directEnable));
+        directEnable = Boolean.parseBoolean(value);
 
         value = p.getProperty("palette", String.valueOf(Gui.palette));
         Gui.palette = Gui.Palette.valueOf(value);
@@ -313,13 +319,15 @@ public class App {
         p.setProperty("numOfBlocks", String.valueOf(numOfBlocks));
         p.setProperty("blockSizeKb", String.valueOf(blockSizeKb));
         p.setProperty("numOfThreads", String.valueOf(numOfThreads));
+        p.setProperty("ioEngine", ioEngine.name());
         p.setProperty("writeSyncEnable", String.valueOf(writeSyncEnable));
+        p.setProperty("directEnable", String.valueOf(directEnable));
         p.setProperty("palette", Gui.palette.name());
 
         // write properties file
         try {
             OutputStream out = new FileOutputStream(PROPERTIES_FILE);
-            p.store(out, "JDiskMark Properties File");
+            p.store(out, "JDiskMark " + VERSION + " Properties File");
         } catch (IOException ex) {
             Logger.getLogger(SelectDriveFrame.class.getName()).log(Level.SEVERE, null, ex);
         }
@@ -335,7 +343,7 @@ public class App {
     
     public static String getConfigString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("Config for JDiskMark ").append(App.VERSION).append('\n');
+        sb.append("Config for JDiskMark ").append(VERSION).append('\n');
         sb.append("readTest: ").append(isReadEnabled()).append('\n');
         sb.append("writeTest: ").append(isWriteEnabled()).append('\n');
         sb.append("locationDir: ").append(locationDir).append('\n');
@@ -349,7 +357,10 @@ public class App {
         sb.append("blockSizeKb: ").append(blockSizeKb).append('\n');
         sb.append("numOfThreads: ").append(numOfThreads).append('\n');
         sb.append("palette: ").append(Gui.palette).append('\n');
-        sb.append("ioMode: ").append(benchmarkType).append('\n');
+        sb.append("benchmarkType: ").append(benchmarkType).append('\n');
+        sb.append("ioEngine: ").append(ioEngine).append('\n');
+        sb.append("writeSyncEnable: ").append(writeSyncEnable).append('\n');
+        sb.append("directEnable: ").append(directEnable).append('\n');
         return sb.toString();
     }
     

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -62,6 +62,29 @@ public class App {
         @Override public String toString() { return label; }
     }
     public static IoEngine ioEngine = IoEngine.MODERN;
+    
+    public enum SectorAlignment {
+        ALIGN_512(512, "512 B (Legacy)"),
+        ALIGN_4K(4096, "4 KB (Standard)"),
+        ALIGN_8K(8192, "8 KB (Enterprise)"),
+        ALIGN_16K(16384, "16 KB (High-End)"),
+        ALIGN_64K(65536, "64 KB (RAID/Stripe)");
+
+        public final int bytes;
+        public final String label;
+
+        SectorAlignment(int bytes, String label) {
+            this.bytes = bytes;
+            this.label = label;
+        }
+
+        @Override
+        public String toString() {
+            return label;
+        }
+    }
+    public static SectorAlignment sectorAlignment = SectorAlignment.ALIGN_4K;
+    
     // member
     public static Properties p;
     public static File locationDir = null;
@@ -200,7 +223,7 @@ public class App {
             Gui.runPanel.hideFirstColumn();
             Gui.selFrame = new SelectDriveFrame();
             System.out.println(getConfigString());
-            Gui.mainFrame.loadConfig();
+            Gui.mainFrame.loadPropertiesConfig();
             Gui.mainFrame.setLocationRelativeTo(null);
             Gui.progressBar = Gui.mainFrame.getProgressBar();
         }
@@ -302,6 +325,9 @@ public class App {
         
         value = p.getProperty("directEnable", String.valueOf(directEnable));
         directEnable = Boolean.parseBoolean(value);
+        
+        value = p.getProperty("sectorAlignment", sectorAlignment.name());
+        sectorAlignment = SectorAlignment.valueOf(value.toUpperCase());
 
         value = p.getProperty("palette", String.valueOf(Gui.palette));
         Gui.palette = Gui.Palette.valueOf(value);
@@ -326,6 +352,7 @@ public class App {
         p.setProperty("ioEngine", ioEngine.name());
         p.setProperty("writeSyncEnable", String.valueOf(writeSyncEnable));
         p.setProperty("directEnable", String.valueOf(directEnable));
+        p.setProperty("sectorAlignment", sectorAlignment.name());
         p.setProperty("palette", Gui.palette.name());
 
         // write properties file

--- a/src/jdiskmark/BenchmarkCallable.java
+++ b/src/jdiskmark/BenchmarkCallable.java
@@ -290,8 +290,8 @@ public class BenchmarkCallable implements Callable<Benchmark> {
                         App.updateMetrics(sample);
                         if (App.verbose) {
                             switch (sample.type) {
-                                case Sample.Type.WRITE -> System.out.println("w: " + s);
-                                case Sample.Type.READ -> System.out.println("r: " + s);
+                                case WRITE -> System.out.println("w: " + s);
+                                case READ -> System.out.println("r: " + s);
                             }
                         }
                         rOperation.bwMax = sample.cumMax;

--- a/src/jdiskmark/BenchmarkCallable.java
+++ b/src/jdiskmark/BenchmarkCallable.java
@@ -190,8 +190,8 @@ public class BenchmarkCallable implements Callable<Benchmark> {
                         App.updateMetrics(sample);
                         if (App.verbose) {
                             switch (sample.type) {
-                                case Sample.Type.WRITE -> System.out.println("w: " + s);
-                                case Sample.Type.READ -> System.out.println("r: " + s);
+                                case WRITE -> System.out.println("w: " + s);
+                                case READ -> System.out.println("r: " + s);
                             }
                         }
                         wOperation.bwMax = sample.cumMax;

--- a/src/jdiskmark/BenchmarkCallable.java
+++ b/src/jdiskmark/BenchmarkCallable.java
@@ -187,9 +187,6 @@ public class BenchmarkCallable implements Callable<Benchmark> {
                         double sec = (double) elapsedTimeNs / 1_000_000_000d;
                         double mbWritten = (double) totalBytesWrittenInSample / (double) MEGABYTE;
                         sample.bwMbSec = mbWritten / sec;
-//                        msg("s:" + s + " write IO is " + sample.getBwMbSecDisplay() + " MB/s   "
-//                                + "(" + Util.displayString(mbWritten) + "MB written in "
-//                                + Util.displayString(sec) + " sec) elapsedNs: " + elapsedTimeNs);
                         App.updateMetrics(sample);
                         if (App.verbose) {
                             switch (sample.type) {
@@ -290,9 +287,6 @@ public class BenchmarkCallable implements Callable<Benchmark> {
                         double sec = (double) elapsedTimeNs / 1_000_000_000d;
                         double mbRead = (double) totalBytesReadInMark / (double) MEGABYTE;
                         sample.bwMbSec = mbRead / sec;
-//                        msg("s:" + s + " read IO is " + sample.getBwMbSecDisplay() + " MB/s   "
-//                                + "(" + Util.displayString(mbRead) + "MB read in "
-//                                + Util.displayString(sec) + " sec) elapsedNs: " + elapsedTimeNs);
                         App.updateMetrics(sample);
                         if (App.verbose) {
                             switch (sample.type) {

--- a/src/jdiskmark/BenchmarkProfile.java
+++ b/src/jdiskmark/BenchmarkProfile.java
@@ -47,24 +47,23 @@ public enum BenchmarkProfile {
     );
     
     // basic settings
-    private String name;
-    private BenchmarkType benchmarkType;
-    private BlockSequence blockSequence;
-    private int numThreads;       // The -T argument
-    private int numSamples;       // The -n argument
-    private int numBlocks = 1;    // The number of blocks per sample
-    private int blockSizeKb;      // The size of a block in KB
+    final private String name;
+    final private BenchmarkType benchmarkType;
+    final private BlockSequence blockSequence;
+    final private int numThreads;       // The -T argument
+    final private int numSamples;       // The -n argument
+    final private int numBlocks;        // The number of blocks per sample
+    final private int blockSizeKb;      // The size of a block in KB
     
     // advanced settings
-    private boolean multiFile = true;      // Whether to use a single test file or multiple
-    private boolean writeSyncEnable = false; // Whether to use synchronous write mode ("rwd")    
+    final private boolean multiFile = true;        // Whether to use a single test file or multiple
+    final private boolean writeSyncEnable = false; // Whether to use synchronous write mode ("rwd")    
     
     // --- Constructor ---
     
     BenchmarkProfile(String name, BenchmarkType benchmarkType,
-        BlockSequence blockSequence, int numberThreads, int numSamples,
-        int numBlocks, int blockSizeKB) {
-        
+            BlockSequence blockSequence, int numberThreads, int numSamples,
+            int numBlocks, int blockSizeKB) {
         this.name = name;
         this.benchmarkType = benchmarkType;
         this.blockSequence = blockSequence;
@@ -99,69 +98,4 @@ public enum BenchmarkProfile {
     public int getBlockSizeKb() { return blockSizeKb; }
     public boolean isMultiFile() { return multiFile; }
     public boolean isWriteSyncEnable() { return writeSyncEnable; }
-    
-    // --- Setters ---
-    
-    public void setName(String name) {
-        if (name == null || name.trim().isEmpty()) {
-            throw new IllegalArgumentException("Profile name cannot be empty.");
-        }
-        this.name = name;
-    }
-
-    public void setBenchmarkType(BenchmarkType benchmarkType) {
-        if (benchmarkType == null) {
-            throw new IllegalArgumentException("BenchmarkType cannot be null.");
-        }
-        this.benchmarkType = benchmarkType;
-    }
-
-    public void setBlockSequence(BlockSequence blockSequence) {
-        if (blockSequence == null) {
-            throw new IllegalArgumentException("BlockSequence cannot be null.");
-        }
-        this.blockSequence = blockSequence;
-    }
-
-    public void setNumThreads(int numThreads) {
-        // Threads must be at least 1
-        if (numThreads < 1) {
-            throw new IllegalArgumentException("Number of threads must be 1 or greater.");
-        }
-        this.numThreads = numThreads;
-    }
-
-    public void setNumSamples(int numSamples) {
-        // Samples must be at least 1 to generate data points
-        if (numSamples < 1) {
-            throw new IllegalArgumentException("Number of samples must be 1 or greater.");
-        }
-        this.numSamples = numSamples;
-    }
-
-    public void setNumBlocks(int numBlocks) {
-        // Blocks per sample must be at least 1
-        if (numBlocks < 1) {
-            throw new IllegalArgumentException("Number of blocks per sample must be 1 or greater.");
-        }
-        this.numBlocks = numBlocks;
-    }
-
-    public void setBlockSizeKb(int blockSizeKb) {
-        // Block size should be a positive, reasonable value (e.g., at least 1KB)
-        if (blockSizeKb < 1) {
-            throw new IllegalArgumentException("Block size in KB must be 1 or greater.");
-        }
-        this.blockSizeKb = blockSizeKb;
-    }
-
-    // --- Advanced Settings Setters ---
-
-    public void setMultiFile(boolean multiFile) {
-        this.multiFile = multiFile;
-    }
-
-    public void setWriteSyncEnable(boolean writeSyncEnable) {
-        this.writeSyncEnable = writeSyncEnable;
-    }
 }

--- a/src/jdiskmark/BenchmarkProfile.java
+++ b/src/jdiskmark/BenchmarkProfile.java
@@ -8,7 +8,43 @@ import jdiskmark.Benchmark.BlockSequence;
  * A named, pre-defined set of configuration parameters for a benchmark run.
  * Corresponds to a "Profile" in the GUI/CLI.
  */
-public class BenchmarkProfile {
+public enum BenchmarkProfile {
+    
+    // --- 1. Max Sequential Speed (Peak Throughput) ---
+    MAX_SEQUENTIAL_SPEED(
+        "Max Sequential", BenchmarkType.READ_WRITE, 
+        BlockSequence.SEQUENTIAL, 1, 100, 200, 1024
+    ),
+
+    // --- 2. High-Load Random (Q32T1 Proxy / Max IOPS) ---
+    HIGH_LOAD_RANDOM_Q32T1(
+        "Random 4K (Q32T1)", BenchmarkType.READ_WRITE, 
+        BlockSequence.RANDOM, 32, 200, 100, 4
+    ),
+
+    // --- 3. Low-Load Random (Q1T1 / System Responsiveness) ---
+    LOW_LOAD_RANDOM_Q1T1(
+        "Random 4K (Q1T1)", BenchmarkType.READ_WRITE, 
+        BlockSequence.RANDOM, 1, 150, 50, 4
+    ),
+
+    // --- 4. Max Write Stress (Endurance/Sustained Write Test) ---
+    MAX_WRITE_STRESS(
+        "Max Write Stress", BenchmarkType.WRITE, 
+        BlockSequence.SEQUENTIAL, 4, 250, 500, 512
+    ),
+
+    // --- 5. Quick Functional Test (Fastest check) ---
+    QUICK_TEST(
+        "Quick Test", BenchmarkType.READ_WRITE, 
+        BlockSequence.SEQUENTIAL, 1, 50, 25, 64
+    ),
+    
+    // --- 6. Custom ---
+    CUSTOM_TEST(
+        "Custom Test", BenchmarkType.READ_WRITE, 
+        BlockSequence.SEQUENTIAL, 1, 1, 1, 1
+    );
     
     // basic settings
     private String name;
@@ -23,47 +59,9 @@ public class BenchmarkProfile {
     private boolean multiFile = true;      // Whether to use a single test file or multiple
     private boolean writeSyncEnable = false; // Whether to use synchronous write mode ("rwd")    
     
-    // --- Static Predefined Profiles ---
-    
-    // --- 1. Max Sequential Speed (Peak Throughput) ---
-    public static final BenchmarkProfile MAX_SEQUENTIAL_SPEED = new BenchmarkProfile(
-        "Max Sequential", BenchmarkType.READ_WRITE, 
-        BlockSequence.SEQUENTIAL, 1, 100, 200, 1024
-    );
-
-    // --- 2. High-Load Random (Q32T1 Proxy / Max IOPS) ---
-    public static final BenchmarkProfile HIGH_LOAD_RANDOM_Q32T1 = new BenchmarkProfile(
-        "Random 4K (Q32T1)", BenchmarkType.READ_WRITE, 
-        BlockSequence.RANDOM, 32, 200, 100, 4
-    );
-
-    // --- 3. Low-Load Random (Q1T1 / System Responsiveness) ---
-    public static final BenchmarkProfile LOW_LOAD_RANDOM_Q1T1 = new BenchmarkProfile(
-        "Random 4K (Q1T1)", BenchmarkType.READ_WRITE, 
-        BlockSequence.RANDOM, 1, 150, 50, 4
-    );
-
-    // --- 4. Max Write Stress (Endurance/Sustained Write Test) ---
-    public static final BenchmarkProfile MAX_WRITE_STRESS = new BenchmarkProfile(
-        "Max Write Stress", BenchmarkType.WRITE, 
-        BlockSequence.SEQUENTIAL, 4, 250, 500, 512
-    );
-
-    // --- 5. Quick Functional Test (Fastest check) ---
-    public static final BenchmarkProfile QUICK_TEST = new BenchmarkProfile(
-        "Quick Test", BenchmarkType.READ_WRITE, 
-        BlockSequence.SEQUENTIAL, 1, 50, 25, 64
-    );
-    
-    // --- 6. Custom ---
-    public static final BenchmarkProfile CUSTOM_TEST = new BenchmarkProfile(
-        "Custom Test", BenchmarkType.READ_WRITE, 
-        BlockSequence.SEQUENTIAL, 1, 1, 1, 1
-    );
-    
     // --- Constructor ---
     
-    public BenchmarkProfile(String name, BenchmarkType benchmarkType,
+    BenchmarkProfile(String name, BenchmarkType benchmarkType,
         BlockSequence blockSequence, int numberThreads, int numSamples,
         int numBlocks, int blockSizeKB) {
         

--- a/src/jdiskmark/BenchmarkWorker.java
+++ b/src/jdiskmark/BenchmarkWorker.java
@@ -35,6 +35,7 @@ import jdiskmark.App.IoEngine;
  */
 public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
 
+    // Minimum milliseconds between progress updates to avoid excessive UI refreshes
     private static final long UPDATE_INTERVAL = 25;
     private final AtomicLong lastUpdateMs = new AtomicLong(0);
 

--- a/src/jdiskmark/Gui.java
+++ b/src/jdiskmark/Gui.java
@@ -420,7 +420,7 @@ public final class Gui {
         App.blockSizeKb = operation.blockSize;
         App.blockSequence = operation.blockOrder;
         App.numOfThreads = operation.numThreads;
-        mainFrame.loadSettings();
+        mainFrame.loadBenchmarkConfig();
         switch (operation.ioMode) {
             case IOMode.READ -> {
                 App.rAvg = operation.bwAvg;

--- a/src/jdiskmark/MainFrame.form
+++ b/src/jdiskmark/MainFrame.form
@@ -133,6 +133,8 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="writeSyncCheckBoxMenuItemActionPerformed"/>
               </Events>
             </MenuItem>
+            <MenuItem class="javax.swing.JPopupMenu$Separator" name="jSeparator3">
+            </MenuItem>
             <MenuItem class="javax.swing.JCheckBoxMenuItem" name="multiFileCheckBoxMenuItem">
               <Properties>
                 <Property name="selected" type="boolean" value="true"/>

--- a/src/jdiskmark/MainFrame.form
+++ b/src/jdiskmark/MainFrame.form
@@ -6,6 +6,8 @@
     </Component>
     <Component class="javax.swing.ButtonGroup" name="ioEnginebuttonGroup">
     </Component>
+    <Component class="javax.swing.ButtonGroup" name="sectorAlignbuttonGroup">
+    </Component>
     <Menu class="javax.swing.JMenuBar" name="menuBar">
       <SubComponents>
         <Menu class="javax.swing.JMenu" name="fileMenu">
@@ -133,6 +135,78 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="writeSyncCheckBoxMenuItemActionPerformed"/>
               </Events>
             </MenuItem>
+            <Menu class="javax.swing.JMenu" name="sectorAlignmentMenu">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="Sector Alignment"/>
+              </Properties>
+              <SubComponents>
+                <MenuItem class="javax.swing.JRadioButtonMenuItem" name="align512RbMenuItem">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="sectorAlignbuttonGroup"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                      <Connection code="App.SectorAlignment.ALIGN_512.toString()" type="code"/>
+                    </Property>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="align512RbMenuItemActionPerformed"/>
+                  </Events>
+                </MenuItem>
+                <MenuItem class="javax.swing.JRadioButtonMenuItem" name="align4KRbMenuItem">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="sectorAlignbuttonGroup"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                      <Connection code="App.SectorAlignment.ALIGN_4K.toString()" type="code"/>
+                    </Property>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="align4KRbMenuItemActionPerformed"/>
+                  </Events>
+                </MenuItem>
+                <MenuItem class="javax.swing.JRadioButtonMenuItem" name="align8KRbMenuItem">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="sectorAlignbuttonGroup"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                      <Connection code="App.SectorAlignment.ALIGN_8K.toString()" type="code"/>
+                    </Property>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="align8KRbMenuItemActionPerformed"/>
+                  </Events>
+                </MenuItem>
+                <MenuItem class="javax.swing.JRadioButtonMenuItem" name="align16KRbMenuItem">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="sectorAlignbuttonGroup"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                      <Connection code="App.SectorAlignment.ALIGN_16K.toString()" type="code"/>
+                    </Property>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="align16KRbMenuItemActionPerformed"/>
+                  </Events>
+                </MenuItem>
+                <MenuItem class="javax.swing.JRadioButtonMenuItem" name="align64KRbMenuItem">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="sectorAlignbuttonGroup"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                      <Connection code="App.SectorAlignment.ALIGN_64K.toString()" type="code"/>
+                    </Property>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="align64KRbMenuItemActionPerformed"/>
+                  </Events>
+                </MenuItem>
+              </SubComponents>
+            </Menu>
             <MenuItem class="javax.swing.JPopupMenu$Separator" name="jSeparator3">
             </MenuItem>
             <MenuItem class="javax.swing.JCheckBoxMenuItem" name="multiFileCheckBoxMenuItem">

--- a/src/jdiskmark/MainFrame.form
+++ b/src/jdiskmark/MainFrame.form
@@ -4,6 +4,8 @@
   <NonVisualComponents>
     <Component class="javax.swing.ButtonGroup" name="palettebuttonGroup">
     </Component>
+    <Component class="javax.swing.ButtonGroup" name="ioEnginebuttonGroup">
+    </Component>
     <Menu class="javax.swing.JMenuBar" name="menuBar">
       <SubComponents>
         <Menu class="javax.swing.JMenu" name="fileMenu">
@@ -84,6 +86,44 @@
             <Property name="text" type="java.lang.String" value="Options"/>
           </Properties>
           <SubComponents>
+            <Menu class="javax.swing.JMenu" name="ioEngineMenu">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="IO Engine"/>
+              </Properties>
+              <SubComponents>
+                <MenuItem class="javax.swing.JRadioButtonMenuItem" name="engModernRbMenuItem">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="ioEnginebuttonGroup"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" value="Modern (FFM API)"/>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="engModernRbMenuItemActionPerformed"/>
+                  </Events>
+                </MenuItem>
+                <MenuItem class="javax.swing.JRadioButtonMenuItem" name="engLegacyRbMenuItem">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="ioEnginebuttonGroup"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" value="Legacy (RandomAccessFile)"/>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="engLegacyRbMenuItemActionPerformed"/>
+                  </Events>
+                </MenuItem>
+              </SubComponents>
+            </Menu>
+            <MenuItem class="javax.swing.JCheckBoxMenuItem" name="directIoCbMenuItem">
+              <Properties>
+                <Property name="selected" type="boolean" value="true"/>
+                <Property name="text" type="java.lang.String" value="Direct IO (unbuffered)"/>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="directIoCbMenuItemActionPerformed"/>
+              </Events>
+            </MenuItem>
             <MenuItem class="javax.swing.JCheckBoxMenuItem" name="writeSyncCheckBoxMenuItem">
               <Properties>
                 <Property name="selected" type="boolean" value="true"/>

--- a/src/jdiskmark/MainFrame.java
+++ b/src/jdiskmark/MainFrame.java
@@ -15,6 +15,8 @@ import javax.swing.DefaultComboBoxModel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.text.DefaultCaret;
+import static jdiskmark.App.IoEngine.MODERN;
+import static jdiskmark.App.SectorAlignment.ALIGN_512;
 import jdiskmark.Benchmark.BenchmarkType;
 import jdiskmark.Benchmark.BlockSequence;
 
@@ -92,17 +94,17 @@ public final class MainFrame extends javax.swing.JFrame {
      * This method is called when the gui needs to be updated after a new config
      * has been loaded.
      */
-    public void loadConfig() {
+    public void loadPropertiesConfig() {
+        loadBenchmarkConfig();
         if (App.locationDir != null) { // set the location dir if not null
             setLocation(App.locationDir.getAbsolutePath());
         }
         multiFileCheckBoxMenuItem.setSelected(App.multiFile);
         autoRemoveCheckBoxMenuItem.setSelected(App.autoRemoveData);
         autoResetCheckBoxMenuItem.setSelected(App.autoReset);
+        // display preferences
         showMaxMinCheckBoxMenuItem.setSelected(App.showMaxMin);
         showAccessCheckBoxMenuItem.setSelected(App.showDriveAccess);
-        writeSyncCheckBoxMenuItem.setSelected(App.writeSyncEnable);
-
         switch (Gui.palette) {
             case Gui.Palette.CLASSIC -> {
                 classicPaletteMenuItem.setSelected(true);
@@ -135,7 +137,7 @@ public final class MainFrame extends javax.swing.JFrame {
     }
     
     public void initializeComboSettings() {
-        loadSettings();
+        loadBenchmarkConfig();
         
         // action listeners to detect change and update custom profile
         final BenchmarkType[] previousBenchmarkType = { (BenchmarkType) typeCombo.getSelectedItem() };
@@ -191,8 +193,7 @@ public final class MainFrame extends javax.swing.JFrame {
         });
     }
 
-    // later rename to loadBenchmarkConfiguration
-    public void loadSettings() {
+    public void loadBenchmarkConfig() {
         profileCombo.setSelectedItem(App.activeProfile);
         typeCombo.setSelectedItem(App.benchmarkType);
         // basic benchmark config
@@ -204,10 +205,20 @@ public final class MainFrame extends javax.swing.JFrame {
         numSamplesCombo.setSelectedItem(String.valueOf(App.numOfSamples));
         // advanced benchmark config
         multiFileCheckBoxMenuItem.setSelected(App.multiFile);
-        engModernRbMenuItem.setSelected(App.ioEngine == App.IoEngine.MODERN);
-        engLegacyRbMenuItem.setSelected(App.ioEngine == App.IoEngine.LEGACY);
+        switch (App.ioEngine) {
+            case MODERN -> engModernRbMenuItem.setSelected(true);
+            case LEGACY -> engLegacyRbMenuItem.setSelected(true);
+        }
         writeSyncCheckBoxMenuItem.setSelected(App.writeSyncEnable);
         directIoCbMenuItem.setSelected(App.directEnable);
+        // sector alignment
+        switch (App.sectorAlignment) {
+            case ALIGN_512 -> align512RbMenuItem.setSelected(true);
+            case ALIGN_4K -> align4KRbMenuItem.setSelected(true);
+            case ALIGN_8K -> align8KRbMenuItem.setSelected(true);
+            case ALIGN_16K -> align16KRbMenuItem.setSelected(true);
+            case ALIGN_64K -> align64KRbMenuItem.setSelected(true);
+        }
     }
     
     /**
@@ -221,6 +232,7 @@ public final class MainFrame extends javax.swing.JFrame {
 
         palettebuttonGroup = new javax.swing.ButtonGroup();
         ioEnginebuttonGroup = new javax.swing.ButtonGroup();
+        sectorAlignbuttonGroup = new javax.swing.ButtonGroup();
         tabbedPane = new javax.swing.JTabbedPane();
         runPanel = new jdiskmark.BenchmarkPanel();
         eventScrollPane = new javax.swing.JScrollPane();
@@ -291,6 +303,12 @@ public final class MainFrame extends javax.swing.JFrame {
         engLegacyRbMenuItem = new javax.swing.JRadioButtonMenuItem();
         directIoCbMenuItem = new javax.swing.JCheckBoxMenuItem();
         writeSyncCheckBoxMenuItem = new javax.swing.JCheckBoxMenuItem();
+        sectorAlignmentMenu = new javax.swing.JMenu();
+        align512RbMenuItem = new javax.swing.JRadioButtonMenuItem();
+        align4KRbMenuItem = new javax.swing.JRadioButtonMenuItem();
+        align8KRbMenuItem = new javax.swing.JRadioButtonMenuItem();
+        align16KRbMenuItem = new javax.swing.JRadioButtonMenuItem();
+        align64KRbMenuItem = new javax.swing.JRadioButtonMenuItem();
         jSeparator3 = new javax.swing.JPopupMenu.Separator();
         multiFileCheckBoxMenuItem = new javax.swing.JCheckBoxMenuItem();
         autoRemoveCheckBoxMenuItem = new javax.swing.JCheckBoxMenuItem();
@@ -825,6 +843,55 @@ public final class MainFrame extends javax.swing.JFrame {
             }
         });
         optionMenu.add(writeSyncCheckBoxMenuItem);
+
+        sectorAlignmentMenu.setText("Sector Alignment");
+
+        sectorAlignbuttonGroup.add(align512RbMenuItem);
+        align512RbMenuItem.setText(App.SectorAlignment.ALIGN_512.toString());
+        align512RbMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                align512RbMenuItemActionPerformed(evt);
+            }
+        });
+        sectorAlignmentMenu.add(align512RbMenuItem);
+
+        sectorAlignbuttonGroup.add(align4KRbMenuItem);
+        align4KRbMenuItem.setText(App.SectorAlignment.ALIGN_4K.toString());
+        align4KRbMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                align4KRbMenuItemActionPerformed(evt);
+            }
+        });
+        sectorAlignmentMenu.add(align4KRbMenuItem);
+
+        sectorAlignbuttonGroup.add(align8KRbMenuItem);
+        align8KRbMenuItem.setText(App.SectorAlignment.ALIGN_8K.toString());
+        align8KRbMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                align8KRbMenuItemActionPerformed(evt);
+            }
+        });
+        sectorAlignmentMenu.add(align8KRbMenuItem);
+
+        sectorAlignbuttonGroup.add(align16KRbMenuItem);
+        align16KRbMenuItem.setText(App.SectorAlignment.ALIGN_16K.toString());
+        align16KRbMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                align16KRbMenuItemActionPerformed(evt);
+            }
+        });
+        sectorAlignmentMenu.add(align16KRbMenuItem);
+
+        sectorAlignbuttonGroup.add(align64KRbMenuItem);
+        align64KRbMenuItem.setText(App.SectorAlignment.ALIGN_64K.toString());
+        align64KRbMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                align64KRbMenuItemActionPerformed(evt);
+            }
+        });
+        sectorAlignmentMenu.add(align64KRbMenuItem);
+
+        optionMenu.add(sectorAlignmentMenu);
         optionMenu.add(jSeparator3);
 
         multiFileCheckBoxMenuItem.setSelected(true);
@@ -1158,25 +1225,60 @@ public final class MainFrame extends javax.swing.JFrame {
         App.writeSyncEnable = profile.isWriteSyncEnable();
         App.multiFile = profile.isMultiFile();
         
-        loadSettings();
+        loadBenchmarkConfig();
     }//GEN-LAST:event_profileComboActionPerformed
 
     private void directIoCbMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_directIoCbMenuItemActionPerformed
         App.directEnable = directIoCbMenuItem.isSelected();
+        App.saveConfig();
     }//GEN-LAST:event_directIoCbMenuItemActionPerformed
 
     private void engModernRbMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_engModernRbMenuItemActionPerformed
         App.ioEngine = App.IoEngine.MODERN;
         directIoCbMenuItem.setEnabled(true);
+        sectorAlignmentMenu.setEnabled(true);
+        App.saveConfig();
     }//GEN-LAST:event_engModernRbMenuItemActionPerformed
 
     private void engLegacyRbMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_engLegacyRbMenuItemActionPerformed
         App.ioEngine = App.IoEngine.LEGACY;
         directIoCbMenuItem.setEnabled(false);
+        sectorAlignmentMenu.setEnabled(false);
+        App.saveConfig();
     }//GEN-LAST:event_engLegacyRbMenuItemActionPerformed
+
+    private void align512RbMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_align512RbMenuItemActionPerformed
+        App.sectorAlignment = App.SectorAlignment.ALIGN_512;
+        App.saveConfig();
+    }//GEN-LAST:event_align512RbMenuItemActionPerformed
+
+    private void align4KRbMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_align4KRbMenuItemActionPerformed
+        App.sectorAlignment = App.SectorAlignment.ALIGN_4K;
+        App.saveConfig();
+    }//GEN-LAST:event_align4KRbMenuItemActionPerformed
+
+    private void align8KRbMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_align8KRbMenuItemActionPerformed
+        App.sectorAlignment = App.SectorAlignment.ALIGN_8K;
+        App.saveConfig();
+    }//GEN-LAST:event_align8KRbMenuItemActionPerformed
+
+    private void align16KRbMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_align16KRbMenuItemActionPerformed
+        App.sectorAlignment = App.SectorAlignment.ALIGN_16K;
+        App.saveConfig();
+    }//GEN-LAST:event_align16KRbMenuItemActionPerformed
+
+    private void align64KRbMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_align64KRbMenuItemActionPerformed
+        App.sectorAlignment = App.SectorAlignment.ALIGN_64K;
+        App.saveConfig();
+    }//GEN-LAST:event_align64KRbMenuItemActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JMenu actionMenu;
+    private javax.swing.JRadioButtonMenuItem align16KRbMenuItem;
+    private javax.swing.JRadioButtonMenuItem align4KRbMenuItem;
+    private javax.swing.JRadioButtonMenuItem align512RbMenuItem;
+    private javax.swing.JRadioButtonMenuItem align64KRbMenuItem;
+    private javax.swing.JRadioButtonMenuItem align8KRbMenuItem;
     private javax.swing.JCheckBoxMenuItem autoRemoveCheckBoxMenuItem;
     private javax.swing.JCheckBoxMenuItem autoResetCheckBoxMenuItem;
     private javax.swing.JRadioButtonMenuItem bardCoolPaletteMenuItem;
@@ -1251,6 +1353,8 @@ public final class MainFrame extends javax.swing.JFrame {
     private javax.swing.JMenuItem resetSequenceMenuItem;
     private jdiskmark.BenchmarkPanel runPanel;
     private javax.swing.JLabel sampleSizeLabel;
+    private javax.swing.ButtonGroup sectorAlignbuttonGroup;
+    private javax.swing.JMenu sectorAlignmentMenu;
     private javax.swing.JCheckBoxMenuItem showAccessCheckBoxMenuItem;
     private javax.swing.JCheckBoxMenuItem showMaxMinCheckBoxMenuItem;
     private javax.swing.JButton startButton;

--- a/src/jdiskmark/MainFrame.java
+++ b/src/jdiskmark/MainFrame.java
@@ -207,7 +207,11 @@ public final class MainFrame extends javax.swing.JFrame {
         multiFileCheckBoxMenuItem.setSelected(App.multiFile);
         switch (App.ioEngine) {
             case MODERN -> engModernRbMenuItem.setSelected(true);
-            case LEGACY -> engLegacyRbMenuItem.setSelected(true);
+            case LEGACY -> {
+                engLegacyRbMenuItem.setSelected(true);
+                directIoCbMenuItem.setEnabled(false);
+                sectorAlignmentMenu.setEnabled(false);
+            }
         }
         writeSyncCheckBoxMenuItem.setSelected(App.writeSyncEnable);
         directIoCbMenuItem.setSelected(App.directEnable);

--- a/src/jdiskmark/MainFrame.java
+++ b/src/jdiskmark/MainFrame.java
@@ -217,6 +217,7 @@ public final class MainFrame extends javax.swing.JFrame {
     private void initComponents() {
 
         palettebuttonGroup = new javax.swing.ButtonGroup();
+        ioEnginebuttonGroup = new javax.swing.ButtonGroup();
         tabbedPane = new javax.swing.JTabbedPane();
         runPanel = new jdiskmark.BenchmarkPanel();
         eventScrollPane = new javax.swing.JScrollPane();
@@ -282,6 +283,10 @@ public final class MainFrame extends javax.swing.JFrame {
         resetSequenceMenuItem = new javax.swing.JMenuItem();
         resetBenchmarkItem = new javax.swing.JMenuItem();
         optionMenu = new javax.swing.JMenu();
+        ioEngineMenu = new javax.swing.JMenu();
+        engModernRbMenuItem = new javax.swing.JRadioButtonMenuItem();
+        engLegacyRbMenuItem = new javax.swing.JRadioButtonMenuItem();
+        directIoCbMenuItem = new javax.swing.JCheckBoxMenuItem();
         writeSyncCheckBoxMenuItem = new javax.swing.JCheckBoxMenuItem();
         multiFileCheckBoxMenuItem = new javax.swing.JCheckBoxMenuItem();
         autoRemoveCheckBoxMenuItem = new javax.swing.JCheckBoxMenuItem();
@@ -777,6 +782,37 @@ public final class MainFrame extends javax.swing.JFrame {
 
         optionMenu.setText("Options");
 
+        ioEngineMenu.setText("IO Engine");
+
+        ioEnginebuttonGroup.add(engModernRbMenuItem);
+        engModernRbMenuItem.setText("Modern (FFM API)");
+        engModernRbMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                engModernRbMenuItemActionPerformed(evt);
+            }
+        });
+        ioEngineMenu.add(engModernRbMenuItem);
+
+        ioEnginebuttonGroup.add(engLegacyRbMenuItem);
+        engLegacyRbMenuItem.setText("Legacy (RandomAccessFile)");
+        engLegacyRbMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                engLegacyRbMenuItemActionPerformed(evt);
+            }
+        });
+        ioEngineMenu.add(engLegacyRbMenuItem);
+
+        optionMenu.add(ioEngineMenu);
+
+        directIoCbMenuItem.setSelected(true);
+        directIoCbMenuItem.setText("Direct IO (unbuffered)");
+        directIoCbMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                directIoCbMenuItemActionPerformed(evt);
+            }
+        });
+        optionMenu.add(directIoCbMenuItem);
+
         writeSyncCheckBoxMenuItem.setSelected(true);
         writeSyncCheckBoxMenuItem.setText("Write Sync");
         writeSyncCheckBoxMenuItem.addActionListener(new java.awt.event.ActionListener() {
@@ -1120,6 +1156,20 @@ public final class MainFrame extends javax.swing.JFrame {
         loadSettings();
     }//GEN-LAST:event_profileComboActionPerformed
 
+    private void directIoCbMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_directIoCbMenuItemActionPerformed
+        App.directEnable = directIoCbMenuItem.isSelected();
+    }//GEN-LAST:event_directIoCbMenuItemActionPerformed
+
+    private void engModernRbMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_engModernRbMenuItemActionPerformed
+        App.ioEngine = App.IoEngine.MODERN;
+        directIoCbMenuItem.setEnabled(true);
+    }//GEN-LAST:event_engModernRbMenuItemActionPerformed
+
+    private void engLegacyRbMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_engLegacyRbMenuItemActionPerformed
+        App.ioEngine = App.IoEngine.LEGACY;
+        directIoCbMenuItem.setEnabled(false);
+    }//GEN-LAST:event_engLegacyRbMenuItemActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JMenu actionMenu;
     private javax.swing.JCheckBoxMenuItem autoRemoveCheckBoxMenuItem;
@@ -1137,9 +1187,14 @@ public final class MainFrame extends javax.swing.JFrame {
     private javax.swing.JMenuItem deleteAllBenchmarksItem;
     private javax.swing.JMenuItem deleteDataMenuItem;
     private javax.swing.JMenuItem deleteSelBenchmarksItem;
+    private javax.swing.JCheckBoxMenuItem directIoCbMenuItem;
+    private javax.swing.JRadioButtonMenuItem engLegacyRbMenuItem;
+    private javax.swing.JRadioButtonMenuItem engModernRbMenuItem;
     private javax.swing.JScrollPane eventScrollPane;
     private javax.swing.JMenu fileMenu;
     private javax.swing.JMenu helpMenu;
+    private javax.swing.JMenu ioEngineMenu;
+    private javax.swing.ButtonGroup ioEnginebuttonGroup;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel10;
     private javax.swing.JLabel jLabel11;

--- a/src/jdiskmark/MainFrame.java
+++ b/src/jdiskmark/MainFrame.java
@@ -204,7 +204,10 @@ public final class MainFrame extends javax.swing.JFrame {
         numSamplesCombo.setSelectedItem(String.valueOf(App.numOfSamples));
         // advanced benchmark config
         multiFileCheckBoxMenuItem.setSelected(App.multiFile);
+        engModernRbMenuItem.setSelected(App.ioEngine == App.IoEngine.MODERN);
+        engLegacyRbMenuItem.setSelected(App.ioEngine == App.IoEngine.LEGACY);
         writeSyncCheckBoxMenuItem.setSelected(App.writeSyncEnable);
+        directIoCbMenuItem.setSelected(App.directEnable);
     }
     
     /**
@@ -288,6 +291,7 @@ public final class MainFrame extends javax.swing.JFrame {
         engLegacyRbMenuItem = new javax.swing.JRadioButtonMenuItem();
         directIoCbMenuItem = new javax.swing.JCheckBoxMenuItem();
         writeSyncCheckBoxMenuItem = new javax.swing.JCheckBoxMenuItem();
+        jSeparator3 = new javax.swing.JPopupMenu.Separator();
         multiFileCheckBoxMenuItem = new javax.swing.JCheckBoxMenuItem();
         autoRemoveCheckBoxMenuItem = new javax.swing.JCheckBoxMenuItem();
         autoResetCheckBoxMenuItem = new javax.swing.JCheckBoxMenuItem();
@@ -821,6 +825,7 @@ public final class MainFrame extends javax.swing.JFrame {
             }
         });
         optionMenu.add(writeSyncCheckBoxMenuItem);
+        optionMenu.add(jSeparator3);
 
         multiFileCheckBoxMenuItem.setSelected(true);
         multiFileCheckBoxMenuItem.setText("Multi Data File");
@@ -1221,6 +1226,7 @@ public final class MainFrame extends javax.swing.JFrame {
     private javax.swing.JMenuItem jMenuItem2;
     private javax.swing.JPopupMenu.Separator jSeparator1;
     private javax.swing.JPopupMenu.Separator jSeparator2;
+    private javax.swing.JPopupMenu.Separator jSeparator3;
     private javax.swing.JPanel locationPanel;
     private javax.swing.JTextField locationText;
     private javax.swing.JMenuBar menuBar;

--- a/src/jdiskmark/Sample.java
+++ b/src/jdiskmark/Sample.java
@@ -6,6 +6,7 @@ import static jdiskmark.Benchmark.BlockSequence.RANDOM;
 // global app settings
 import static jdiskmark.App.blockSequence;
 import static jdiskmark.App.dataDir;
+import static jdiskmark.App.sectorAlignment;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sun.nio.file.ExtendedOpenOption;
@@ -31,8 +32,6 @@ public class Sample {
     static final DecimalFormat DF = new DecimalFormat("###.###");
     static public enum Type { READ, WRITE; }
     
-    static final int SECTOR_ALIGNMENT = 4096;
-    
     Type type;
     int sampleNum = 0;     // x-axis
     double bwMbSec = 0;    // y-axis
@@ -41,7 +40,6 @@ public class Sample {
     double cumMin = 0;
     double accessTimeMs;
     double cumAccTimeMs;
-    
         
     // needed for jackson
     public Sample() {}
@@ -192,7 +190,7 @@ public class Sample {
         try (FileChannel fc = FileChannel.open(testFile.toPath(), options)) {
 
             try (Arena arena = Arena.ofConfined()) {
-                MemorySegment segment = arena.allocate(blockSize, SECTOR_ALIGNMENT);
+                MemorySegment segment = arena.allocate(blockSize, sectorAlignment.bytes);
                 // Populate segment with random data if needed
                 // segment.copyFrom(MemorySegment.ofArray(new byte[(int)bufferSize]));
                 for (int b = 0; b < numOfBlocks; b++) {
@@ -228,7 +226,7 @@ public class Sample {
         try (FileChannel fc = FileChannel.open(testFile.toPath(), options)) {
 
             try (Arena arena = Arena.ofConfined()) {
-                MemorySegment segment = arena.allocate(blockSize, SECTOR_ALIGNMENT);
+                MemorySegment segment = arena.allocate(blockSize, sectorAlignment.bytes);
                 for (int b = 0; b < numOfBlocks; b++) {
                     if (worker.isCancelled()) break;
                     long blockIndex = (blockSequence == RANDOM) ? Util.randInt(0, numOfBlocks - 1) : b;

--- a/src/jdiskmark/Sample.java
+++ b/src/jdiskmark/Sample.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class Sample {
     
     static final DecimalFormat DF = new DecimalFormat("###.###");
-    static public enum Type { READ, WRITE; }
+    enum Type { READ, WRITE; }
     
     Type type;
     int sampleNum = 0;     // x-axis

--- a/src/jdiskmark/Sample.java
+++ b/src/jdiskmark/Sample.java
@@ -242,7 +242,7 @@ public class Sample {
             initialFc = FileChannel.open(testFile.toPath(), options);
         } catch (UnsupportedOperationException e) {
             // Fallback: Remove ExtendedOpenOption.DIRECT and try again
-            App.err("Direct I/O not supported, falling back to buffered I/O.");
+            App.err("Direct I/O is not supported on this system. Falling back to buffered I/O; benchmark results may differ from native Direct I/O performance.");
             options.remove(ExtendedOpenOption.DIRECT);
             try {
                 initialFc = FileChannel.open(testFile.toPath(), options);

--- a/src/jdiskmark/Sample.java
+++ b/src/jdiskmark/Sample.java
@@ -207,8 +207,6 @@ public class Sample {
         
         try (FileChannel fc = initialFc; Arena arena = Arena.ofConfined()) {
             MemorySegment segment = arena.allocate(blockSize, sectorAlignment.bytes);
-            // Populate segment with random data if needed
-            // segment.copyFrom(MemorySegment.ofArray(new byte[(int)bufferSize]));
             for (int b = 0; b < numOfBlocks; b++) {
                 if (worker.isCancelled()) break;
                 long blockIndex = (blockSequence == RANDOM) ?

--- a/src/jdiskmark/Sample.java
+++ b/src/jdiskmark/Sample.java
@@ -5,7 +5,6 @@ import static jdiskmark.App.MEGABYTE;
 import static jdiskmark.Benchmark.BlockSequence.RANDOM;
 // global app settings
 import static jdiskmark.App.blockSequence;
-import static jdiskmark.App.blockSizeKb;
 import static jdiskmark.App.dataDir;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/jdiskmark/Sample.java
+++ b/src/jdiskmark/Sample.java
@@ -192,7 +192,7 @@ public class Sample {
             initialFc = FileChannel.open(testFile.toPath(), options);
         } catch (UnsupportedOperationException e) {
             // Fallback: Remove ExtendedOpenOption.DIRECT and try again
-            App.err("Direct I/O not supported, falling back to buffered I/O.");
+            App.err("Direct I/O is not supported on this system. Falling back to buffered I/O; benchmark results may differ from native Direct I/O performance.");
             options.remove(ExtendedOpenOption.DIRECT);
             try {
                 initialFc = FileChannel.open(testFile.toPath(), options);

--- a/src/jdiskmark/Sample.java
+++ b/src/jdiskmark/Sample.java
@@ -194,7 +194,7 @@ public class Sample {
                 // Populate segment with random data if needed
                 // segment.copyFrom(MemorySegment.ofArray(new byte[(int)bufferSize]));
                 for (int b = 0; b < numOfBlocks; b++) {
-
+                    if (worker.isCancelled()) break;
                     long blockIndex = (blockSequence == RANDOM) ?
                             Util.randInt(0, numOfBlocks - 1) : b;
                     long byteOffset = blockIndex * blockSize;


### PR DESCRIPTION
summary of changes:

1. updating project to jdk25
2. updating io engine to use `FileChannel`, `MemorySegment` and `Arena` to use 4k sector alignment
3. relocating measurement to sample class
4. legacy IO (buffered) option
5. direct IO (unbuffered) option
6. saving and load settings
7. configurable sector alignment

<img width="379" height="276" alt="image" src="https://github.com/user-attachments/assets/e65f92b3-a654-4a69-9de6-207d1bf4af27" />

sector alignment options:

<img width="335" height="236" alt="image" src="https://github.com/user-attachments/assets/a63abad5-bf7c-402c-98ae-89e0848907a0" />

NOTE: I've used `-XDignore.symbol.file` to surpress these warnings on the sun.aip:

```
C:\Users\james\OneDrive\NetBeansProjects\jdm-java\src\jdiskmark\Sample.java:11: warning: ExtendedOpenOption is internal proprietary API and may be removed in a future release

import com.sun.nio.file.ExtendedOpenOption;
```