### PR TITLE
common bench impl - new content creator benchmark modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ debug-benchmark.json
 .VSCodeCounter*
 build.properties
 hs_err_pid*.log
+.DS_Store
 
 # deb packaging
 jdiskmark-deb

--- a/README.md
+++ b/README.md
@@ -107,30 +107,46 @@ java -jar jdiskmark.jar -h
 display benchmark options
 
 ```
-java -jar jdiskmark.jar run -h
-Usage: jdm run [-chsv] [-b=<numOfBlocks>] [-e=<exportPath>] [-l=<locationDir>] [-n=<numOfSamples>]
-               [-o=<blockSequence>] [-t=<benchmarkType>] [-T=<numOfThreads>] [-z=<blockSizeKb>]
+java -jar .\jdiskmark.jar run -h
+Usage: jdiskmark run [-cdhmsvy] [-a=<sectorAlignment>] [-b=<numOfBlocks>] [-e=<exportPath>]
+                     [-i=<ioEngine>] [-l=<locationDir>] [-n=<numOfSamples>] [-o=<blockSequence>]
+                     [-p=<profile>] [-t=<benchmarkType>] [-T=<numOfThreads>] [-z=<blockSizeKb>]
 Starts a disk benchmark test with specified parameters.
+  -a, --alignment=<sectorAlignment>
+                            Sector alignment: NONE, ALIGN_512, ALIGN_4K, ALIGN_8K, ALIGN_16K,
+                              ALIGN_64K. (Profile default used if not specified)
   -b, --blocks=<numOfBlocks>
-                  Number of blocks/chunks per sample. (Default: 32)
-  -c, --clean     Remove existing JDiskMark data directory before starting.
-  -e, --export=<exportPath>
-                  The output file to export benchmark results in json format.
-  -h, --help      Display this help and exit.
+                            Number of blocks/chunks per sample. (Profile default used if not
+                              specified)
+  -c, --clean               Remove existing JDiskMark data directory before starting.
+  -d, --direct              Enable Direct I/O (bypass OS cache). Only works with MODERN engine.
+  -e, --export=<exportPath> The output file to export benchmark results in json format.
+  -h, --help                Display this help and exit.
+  -i, --io-engine=<ioEngine>
+                            I/O Engine: MODERN, LEGACY. (Profile default used if not specified)
   -l, --location=<locationDir>
-                  The directory path where test files will be created.
+                            The directory path where test files will be created.
+  -m, --multi-file          Create a new file for every sample instead of using one large file.
   -n, --samples=<numOfSamples>
-                  Total number of samples/files to write/read. (Default: 200)
+                            Total number of samples/files to write/read. (Profile default used if
+                              not specified)
   -o, --order=<blockSequence>
-                  Block order: Sequential, Random. (Default: SEQUENTIAL)
-  -s, --save      Enable saving the benchmark.
+                            Block order: SEQUENTIAL, RANDOM. (Profile default used if not specified)
+  -p, --profile=<profile>   Profile: QUICK_TEST, MAX_THROUGHPUT, HIGH_LOAD_RANDOM_T32,
+                              LOW_LOAD_RANDOM_T1, MAX_WRITE_STRESS, MEDIA_PLAYBACK,
+                              VIDEO_EXPORTING, PHOTO_LIBRARY. (Default: QUICK_TEST)
+  -s, --save                Enable saving the benchmark results to the database.
   -t, --type=<benchmarkType>
-                  Benchmark type: Read, Write, Read & Write. (Default: WRITE)
+                            Benchmark type: READ, WRITE, READ_WRITE. (Profile default used if not
+                              specified)
   -T, --threads=<numOfThreads>
-                  Number of threads to use for testing. (Default: 1)
-  -v, --verbose   Enable detailed logging.
+                            Number of threads to use for testing. (Profile default used if not
+                              specified)
+  -v, --verbose             Enable detailed logging.
+  -y, --write-sync          Enable Write Sync (flush to disk).
   -z, --block-size=<blockSizeKb>
-                  Size of a block/chunk in Kilobytes (KB). (Default: 512)
+                            Size of a block/chunk in Kilobytes (KB). (Profile default used if not
+                              specified)
 ```
 
 run benchmarks example syntax
@@ -139,6 +155,7 @@ run benchmarks example syntax
 java -jar jdiskmark.jar run -n 25 -t "Write"
 java -jar jdiskmark.jar run -l D:\ -n 25 -t "Read"
 java -jar jdiskmark.jar run -n 25 -t "Read & Write"
+java -jar jdiskmark.jar run -p MAX_WRITE_STRESS
 ```
 run example benchmark
 ```
@@ -184,11 +201,13 @@ Source is available on our [github repo](https://github.com/JDiskMark/jdm-java/)
 - TODO: #16 pkg installer (MacOS) - tyler
 - TODO: #70 app icon - ian
 - TODO: #33 maven build - lane
-- #40 resolve cross platform gui laf
 - TODO: #78 throttle graphics render - val
 - TODO: #95 disk cache purging - val
 - TODO: #44 gui benchmark export
-- TODO: #121 common benchmark impl for cli and gui
+- #40 resolve cross platform gui laf
+- #121 common benchmark runner for cli and gui
+    - cli options for: profile, direct io, alignment
+    - new profiles: media playback, video export, photo library
 - #67 portal uploads
     - TODO: #117 user portal upload acknowledgement
     - TODO: #118 test interlock or OAuth upload

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -646,14 +646,14 @@ public class App {
             if (rAvg == -1) {
                 rAvg = s.bwMbSec;
             } else {
-                long n = s.sampleNum;
+                int n = s.sampleNum;
                 rAvg = (((double)(n-1) * rAvg) + s.bwMbSec) / (double)n;
             }
             // cumulative access time
             if (rAcc == -1) {
                 rAcc = s.accessTimeMs;
             } else {
-                long n = s.sampleNum;
+                int n = s.sampleNum;
                 rAcc = (((double)(n - 1) * rAcc) + s.accessTimeMs) / (double)n;
             }
             // update sample

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -253,6 +253,32 @@ public class App {
         }
     }
     
+    public static void loadProfile(BenchmarkProfile profile) {
+        try {
+            activeProfile = profile;
+
+            // skip adjustments if custom test was selected
+            if (profile.equals(BenchmarkProfile.CUSTOM_TEST)) {
+                return;
+            }
+
+            // TODO: later relocate into a BenchmarkConfiguration.java
+            benchmarkType = profile.getBenchmarkType();
+            blockSequence = profile.getBlockSequence();
+            numOfThreads = profile.getNumThreads();
+            numOfSamples = profile.getNumSamples();
+            numOfBlocks = profile.getNumBlocks();
+            blockSizeKb = profile.getBlockSizeKb();
+            ioEngine = profile.getIoEngine();
+            directEnable = profile.isDirectEnable();
+            writeSyncEnable = profile.isWriteSyncEnable();
+            sectorAlignment = profile.getSectorAlignment();
+            multiFile = profile.isMultiFile();
+        } finally {
+            saveConfig();
+        }
+    }
+    
     public static void loadConfig() {
         if (PROPERTIES_FILE.exists()) {
             System.out.println("loading: " + PROPERTIES_FILE.getAbsolutePath());

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -620,14 +620,14 @@ public class App {
             if (wAvg == -1) {
                 wAvg = s.bwMbSec;
             } else {
-                long n = s.sampleNum;
+                int n = s.sampleNum;
                 wAvg = (((double)(n - 1) * wAvg) + s.bwMbSec) / (double)n;
             }
             // cumulative access time
             if (wAcc == -1) {
                 wAcc = s.accessTimeMs;
             } else {
-                long n = s.sampleNum;
+                int n = s.sampleNum;
                 wAcc = (((double)(n - 1) * wAcc) + s.accessTimeMs) / (double)n;
             }
             // update sample

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -436,7 +436,7 @@ public class App {
         config.writeSyncEnabled = writeSyncEnable;
         config.sectorAlignment = sectorAlignment;
         config.multiFileEnabled = multiFile;
-        config.testDir = locationDir.getAbsolutePath();
+        config.testDir = dataDir.getAbsolutePath();
         return config;
     }
     

--- a/src/jdiskmark/Benchmark.java
+++ b/src/jdiskmark/Benchmark.java
@@ -179,6 +179,7 @@ public class Benchmark implements Serializable {
         sb.append("-------------------------------------------\n");
         sb.append("JDiskMark Benchmark Results (v").append(App.VERSION).append(")\n");
         sb.append("-------------------------------------------\n");
+        sb.append("Profile: ").append(config.profile.name).append("\n");
         sb.append("Benchmark: ").append(config.benchmarkType).append("\n");
         sb.append("Drive: ").append(App.getDriveModel()).append("\n");
         sb.append("Capacity: ").append(App.getDriveCapacity()).append("\n");

--- a/src/jdiskmark/Benchmark.java
+++ b/src/jdiskmark/Benchmark.java
@@ -139,13 +139,13 @@ public class Benchmark implements Serializable {
 
     // benchmark parameters
     @Embedded
-    final BenchmarkConfig config = new BenchmarkConfig();
+    BenchmarkConfig config = new BenchmarkConfig();
     public BenchmarkConfig getConfig() { return config; }
     
     // timestamps
     @Convert(converter = LocalDateTimeAttributeConverter.class)
     @Column(name = "startTime", columnDefinition = "TIMESTAMP")
-    final LocalDateTime startTime;
+    LocalDateTime startTime;
     @Convert(converter = LocalDateTimeAttributeConverter.class)
     @Column
     LocalDateTime endTime = null;
@@ -205,20 +205,18 @@ public class Benchmark implements Serializable {
         return sb.toString();
     }
     
-    public Benchmark() {
-        this(BenchmarkType.WRITE);
+    public Benchmark() {}
+    
+    public Benchmark(BenchmarkConfig config) {
+        this.config = config;
     }
     
-    public Benchmark(BenchmarkType type) {
+    public void recordStartTime() {
         startTime = LocalDateTime.now();
-        config.profile = App.activeProfile;
-        config.benchmarkType = type;
-        config.numSamples = App.numOfSamples;
-        config.numBlocks = App.numOfBlocks;
-        config.blockSize = App.blockSizeKb;
-        config.blockOrder = App.blockSequence;
-        config.writeSyncEnabled = App.writeSyncEnable;
-        config.txSize = App.targetTxSizeKb();
+    }
+    
+    public void recordEndTime() {
+        endTime = LocalDateTime.now();
     }
     
     // basic getters and setters

--- a/src/jdiskmark/BenchmarkCallable.java
+++ b/src/jdiskmark/BenchmarkCallable.java
@@ -65,7 +65,7 @@ public class BenchmarkCallable implements Callable<Benchmark> {
 
     @Override
     public Benchmark call() throws Exception {
-        // 1. Profile Awareness: Apply "Quick Test" as the default CLI behavior if not specified
+        // Apply "Quick Test" as the default CLI behavior if not specified
         if (App.activeProfile == null) {
             App.loadProfile(BenchmarkProfile.QUICK_TEST);
         }

--- a/src/jdiskmark/BenchmarkCallable.java
+++ b/src/jdiskmark/BenchmarkCallable.java
@@ -25,7 +25,7 @@ import static jdiskmark.App.numOfSamples;
 import static jdiskmark.App.testFile;
 import static jdiskmark.Benchmark.BlockSequence;
 import static jdiskmark.Benchmark.IOMode;
-import static jdiskmark.BenchmarkWorker.divideIntoRanges;
+import static jdiskmark.BenchmarkLogic.divideIntoRanges;
 import static jdiskmark.Sample.Type.READ;
 import static jdiskmark.Sample.Type.WRITE;
 

--- a/src/jdiskmark/BenchmarkCallable.java
+++ b/src/jdiskmark/BenchmarkCallable.java
@@ -66,8 +66,9 @@ public class BenchmarkCallable implements Callable<Benchmark> {
     @Override
     public Benchmark call() throws Exception {
         // 1. Profile Awareness: Apply "Quick Test" as the default CLI behavior if not specified
-        
-        App.loadProfile(BenchmarkProfile.QUICK_TEST);
+        if (App.activeProfile == null) {
+            App.loadProfile(BenchmarkProfile.QUICK_TEST);
+        }
 
         System.out.println(App.benchmarkType + " benchmark started...");
         long start = System.currentTimeMillis();

--- a/src/jdiskmark/BenchmarkCallable.java
+++ b/src/jdiskmark/BenchmarkCallable.java
@@ -8,7 +8,7 @@ import static jdiskmark.App.msg;
 
 /**
  * CLI version of the benchmark runner.
- * Uses BenchmarkLogic to perform the disk I/O while rendering a progress bar.
+ * Uses BenchmarkRunner to perform the disk I/O while rendering a progress bar.
  */
 public class BenchmarkCallable implements Callable<Benchmark> {
     private static final Logger logger = Logger.getLogger(BenchmarkCallable.class.getName());
@@ -33,7 +33,7 @@ public class BenchmarkCallable implements Callable<Benchmark> {
     }
     
     // Implementation of the listener for CLI output
-    private final BenchmarkLogic.BenchmarkListener listener = new BenchmarkLogic.BenchmarkListener() {
+    private final BenchmarkRunner.BenchmarkListener listener = new BenchmarkRunner.BenchmarkListener() {
         @Override
         public void onSampleComplete(Sample s) {
             if (App.verbose) {
@@ -79,9 +79,9 @@ public class BenchmarkCallable implements Callable<Benchmark> {
             App.resetTestData();
         }
 
-        // Execute benchmark Logic
-        BenchmarkLogic logic = new BenchmarkLogic(listener);
-        Benchmark benchmark = logic.execute();
+        // Execute benchmark
+        BenchmarkRunner bRunner = new BenchmarkRunner(listener);
+        Benchmark benchmark = bRunner.execute();
 
         // Post-benchmark persistence and export
         if (App.autoSave) {

--- a/src/jdiskmark/BenchmarkCallable.java
+++ b/src/jdiskmark/BenchmarkCallable.java
@@ -1,347 +1,111 @@
 package jdiskmark;
 
 import jakarta.persistence.EntityManager;
-import java.io.File;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import static jdiskmark.App.KILOBYTE;
-import static jdiskmark.App.MEGABYTE;
-import static jdiskmark.App.blockSizeKb;
-import static jdiskmark.App.dataDir;
-import static jdiskmark.App.locationDir;
 import static jdiskmark.App.msg;
-import static jdiskmark.App.numOfBlocks;
-import static jdiskmark.App.numOfSamples;
-import static jdiskmark.App.testFile;
-import static jdiskmark.Benchmark.BlockSequence;
-import static jdiskmark.Benchmark.IOMode;
-import static jdiskmark.BenchmarkLogic.divideIntoRanges;
-import static jdiskmark.Sample.Type.READ;
-import static jdiskmark.Sample.Type.WRITE;
 
+/**
+ * CLI version of the benchmark runner.
+ * Uses BenchmarkLogic to perform the disk I/O while rendering a progress bar.
+ */
 public class BenchmarkCallable implements Callable<Benchmark> {
+    private static final Logger logger = Logger.getLogger(BenchmarkCallable.class.getName());
     static final int CLI_BAR_LENGTH = 50;
-    Benchmark benchmark;    
-    // this is for rendering a progress bar in the cli
-    private void drawProgressBar(int percent, int totalSamples) {
-        // Ensure percent is capped at 100 for display (in case of >100% on final unit)
-        int displayPercent = Math.min(100, percent); 
+
+    /**
+     * Renders a standard CLI progress bar with a carriage return
+     */
+    private void drawProgressBar(int completed, int total) {
+        float percent = (float) completed / total * 100f;
+        int displayPercent = Math.min(100, (int) percent);
         int numChars = (int) Math.floor((double) displayPercent / 100 * CLI_BAR_LENGTH);
-        String bar = "[";
+        
+        StringBuilder bar = new StringBuilder("[");
         for (int i = 0; i < CLI_BAR_LENGTH; i++) {
-            bar += (i < numChars) ? "#" : " ";
+            bar.append(i < numChars ? "#" : " ");
         }
-        bar += "]";
-        // Print the current progress bar using carriage return (\r)
-        System.out.printf("\rProgress: %s %3d%% (%d total operations) ", bar, displayPercent, totalSamples);
+        bar.append("]");
+        
+        System.out.printf("\rProgress: %s %3d%% (%d/%d units) ", bar.toString(), displayPercent, completed, total);
         System.out.flush();
     }
     
-    // Constructor to pass any necessary data to the task
-    public BenchmarkCallable() {
-    }
+    // Implementation of the listener for CLI output
+    private final BenchmarkLogic.BenchmarkListener listener = new BenchmarkLogic.BenchmarkListener() {
+        @Override
+        public void onSampleComplete(Sample s) {
+            if (App.verbose) {
+                System.out.println(String.format("\n%s Sample %d: %s MB/s", s.type, s.sampleNum, s.getBwMbSecDisplay()));
+            }
+        }
+
+        @Override
+        public void onProgressUpdate(long completed, long total) {
+            drawProgressBar((int) completed, (int) total);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            // CLI benchmarks usually run to completion unless the process is killed
+            return false; 
+        }
+
+        @Override
+        public void requestCacheDrop() {
+            System.out.println("\nDropping OS caches...");
+            Cli.dropCache();
+        }
+    };
+
+    public BenchmarkCallable() {}
+
     @Override
     public Benchmark call() throws Exception {
         System.out.println(App.benchmarkType + " benchmark started...");
-        
-        // The main, long-running logic goes here
         long start = System.currentTimeMillis();
-        
+
         if (App.verbose) {
-            msg("*** starting new worker thread");
+            msg("*** starting new CLI benchmark thread");
             msg("Running readTest " + App.isReadEnabled() + "   writeTest " + App.isWriteEnabled());
             msg("num samples: " + App.numOfSamples + ", num blks: " + App.numOfBlocks
                     + ", blk size (kb): " + App.blockSizeKb + ", blockSequence: "
                     + App.blockSequence);
         }
 
-        // GH-20 final to aid w lambda usage
-        final int[] wUnitsComplete = {0};
-        final int[] rUnitsComplete = {0};
-        final int[] unitsComplete = {0};
-
-        int wUnitsTotal = App.isWriteEnabled() ? numOfBlocks * numOfSamples : 0;
-        int rUnitsTotal = App.isReadEnabled() ? numOfBlocks * numOfSamples : 0;
-        int unitsTotal = wUnitsTotal + rUnitsTotal;
-
-        int blockSize = blockSizeKb * KILOBYTE;
-        byte[] blockArr = new byte[blockSize];
-        for (int b = 0; b < blockArr.length; b++) {
-            if (b % 2 == 0) {
-                blockArr[b] = (byte) 0xFF;
-            }
-        }
-
-        if (App.autoReset == true) {
+        // Pre-benchmark cleanup
+        if (App.autoReset) {
             App.resetTestData();
         }
 
-        String driveModel = Util.getDriveModel(locationDir);
-        String partitionId = Util.getPartitionId(locationDir.toPath());
-        DiskUsageInfo usageInfo = new DiskUsageInfo(); // init to prevent null ref
-        try {
-            usageInfo = Util.getDiskUsage(locationDir.toString());
-        } catch (IOException | InterruptedException ex) {
-            Logger.getLogger(BenchmarkWorker.class.getName()).log(Level.SEVERE, null, ex);
-        }
-        if (App.verbose) {
-            msg("drive model=" + driveModel + " partitionId=" + partitionId
-                    + " usage=" + usageInfo.toDisplayString());
-        }
-        
-        // GH-20 calculate ranges for concurrent thread IO
-        int sIndex = App.nextSampleNumber;
-        int eIndex = sIndex + numOfSamples;
-        int[][] tRanges = divideIntoRanges(sIndex, eIndex, App.numOfThreads);
+        // Execute benchmark Logic
+        BenchmarkLogic logic = new BenchmarkLogic(listener);
+        Benchmark benchmark = logic.execute();
 
-        // configure the benchmark
-        benchmark = new Benchmark(App.benchmarkType);
-        // system info
-        benchmark.systemInfo.processorName = App.processorName;
-        benchmark.systemInfo.os = App.os;
-        benchmark.systemInfo.arch = App.arch;
-        benchmark.systemInfo.jdk = App.jdk;
-        benchmark.systemInfo.locationDir = App.locationDir.toString();
-        // drive information
-        benchmark.driveInfo.driveModel = driveModel;
-        benchmark.driveInfo.partitionId = partitionId;
-        benchmark.driveInfo.percentUsed = usageInfo.percentUsed;
-        benchmark.driveInfo.usedGb = usageInfo.usedGb;
-        benchmark.driveInfo.totalGb = usageInfo.totalGb;
-        
-        if (App.isWriteEnabled()) {
-            BenchmarkOperation wOperation = new BenchmarkOperation();
-            wOperation.setBenchmark(benchmark);
-            wOperation.ioMode = IOMode.WRITE;
-            wOperation.blockOrder = App.blockSequence;
-            wOperation.numSamples = App.numOfSamples;
-            wOperation.numBlocks = App.numOfSamples;
-            wOperation.blockSize = App.blockSizeKb;
-            wOperation.txSize = App.targetTxSizeKb();
-            wOperation.numThreads = App.numOfThreads;
-            // persist whether write sync was enabled for this run
-            wOperation.setWriteSyncEnabled(App.writeSyncEnable);
-            benchmark.getOperations().add(wOperation);
-
-            if (App.multiFile == false) {
-                testFile = new File(dataDir.getAbsolutePath() + File.separator + "testdata.jdm");
-            }
-
-            // GH-20 instantiate threads to operate on each range
-            ExecutorService executorService = Executors.newFixedThreadPool(App.numOfThreads);
-            List<Future<?>> futures = new ArrayList<>();
-
-            for (int[] range : tRanges) {
-                final int startSample = range[0];
-                final int endSample = range[1];
-
-                futures.add(executorService.submit(() -> {
-
-                    for (int s = startSample; s <= endSample; s++) {
-
-                        if (App.multiFile == true) {
-                            testFile = new File(dataDir.getAbsolutePath()
-                                    + File.separator + "testdata" + s + ".jdm");
-                        }
-                        Sample sample = new Sample(WRITE, s);
-                        long startTime = System.nanoTime();
-                        long totalBytesWrittenInSample = 0;
-                        String mode = (App.writeSyncEnable) ? "rwd" : "rw";
-
-                        try {
-                            try (RandomAccessFile rAccFile = new RandomAccessFile(testFile, mode)) {
-                                for (int b = 0; b < numOfBlocks; b++) {
-                                    if (App.blockSequence == BlockSequence.RANDOM) {
-                                        int rLoc = Util.randInt(0, numOfBlocks - 1);
-                                        rAccFile.seek(rLoc * blockSize);
-                                    } else {
-                                        rAccFile.seek(b * blockSize);
-                                    }
-                                    rAccFile.write(blockArr, 0, blockSize);
-                                    totalBytesWrittenInSample += blockSize;
-                                    synchronized (BenchmarkCallable.this) {
-                                        wUnitsComplete[0]++;
-                                        unitsComplete[0] = rUnitsComplete[0] + wUnitsComplete[0];
-                                        float percentComplete = (float)unitsComplete[0] / (float) unitsTotal * 100f;
-                                        int newProgress = (int) percentComplete;
-                                        drawProgressBar(newProgress, unitsTotal);
-                                    }
-                                }
-                            }
-                        } catch (IOException ex) {
-                            Logger.getLogger(BenchmarkCallable.class.getName()).log(Level.SEVERE, null, ex);
-                        }
-                        long endTime = System.nanoTime();
-                        long elapsedTimeNs = endTime - startTime;
-                        sample.accessTimeMs = (elapsedTimeNs / 1_000_000f) / numOfBlocks;
-                        double sec = (double) elapsedTimeNs / 1_000_000_000d;
-                        double mbWritten = (double) totalBytesWrittenInSample / (double) MEGABYTE;
-                        sample.bwMbSec = mbWritten / sec;
-                        App.updateMetrics(sample);
-                        if (App.verbose) {
-                            switch (sample.type) {
-                                case WRITE -> System.out.println("w: " + s);
-                                case READ -> System.out.println("r: " + s);
-                            }
-                        }
-                        wOperation.bwMax = sample.cumMax;
-                        wOperation.bwMin = sample.cumMin;
-                        wOperation.bwAvg = sample.cumAvg;
-                        wOperation.accAvg = sample.cumAccTimeMs;
-                        wOperation.add(sample);
-                    }
-                }));
-            }
-            // stop accepting new task
-            executorService.shutdown();
-            // block until all tasks are complete
-            for (Future<?> future : futures) {
-                try {
-                    future.get();
-                } catch (InterruptedException ex) {
-                    // The primary benchmark thread was interrupted
-                    Thread.currentThread().interrupt(); 
-                    throw ex; // Re-throw to stop the benchmark
-                } catch (ExecutionException ex) {
-                    Logger.getLogger(BenchmarkWorker.class.getName()).log(Level.SEVERE, "Worker range thread failed.", ex.getCause());
-                    throw new Exception("Benchmark operation failed in worker thread.", ex.getCause());
-                }
-            }
-            // GH-10 file IOPS processing
-            wOperation.endTime = LocalDateTime.now();
-            wOperation.setTotalOps(wUnitsComplete[0]);
-            App.wIops = wOperation.iops;
-        }
-
-        // TODO: review renaming all files to clear catch
-        if (App.isReadEnabled() && App.isWriteEnabled()) {
-            Cli.dropCache();
-        }
-
-        if (App.isReadEnabled()) {
-            BenchmarkOperation rOperation = new BenchmarkOperation();
-            rOperation.setBenchmark(benchmark);
-            // operation parameters
-            rOperation.ioMode = IOMode.READ;
-            rOperation.blockOrder = App.blockSequence;
-            rOperation.numSamples = App.numOfSamples;
-            rOperation.numBlocks = App.numOfBlocks;
-            rOperation.blockSize = App.blockSizeKb;
-            rOperation.txSize = App.targetTxSizeKb();
-            rOperation.numThreads = App.numOfThreads;
-            // write sync does not apply to pure read benchmarks
-            rOperation.setWriteSyncEnabled(null);
-            benchmark.getOperations().add(rOperation);
-
-            ExecutorService executorService = Executors.newFixedThreadPool(App.numOfThreads);
-            List<Future<?>> futures = new ArrayList<>();
-
-            for (int[] range : tRanges) {
-                final int startSample = range[0];
-                final int endSample = range[1];
-                futures.add(executorService.submit(() -> {
-                    for (int s = startSample; s <= endSample; s++) {
-                        if (App.multiFile == true) {
-                            testFile = new File(dataDir.getAbsolutePath()
-                                    + File.separator + "testdata" + s + ".jdm");
-                        }
-                        Sample sample = new Sample(READ, s);
-                        long startTime = System.nanoTime();
-                        long totalBytesReadInMark = 0;
-                        try {
-                            try (RandomAccessFile rAccFile = new RandomAccessFile(testFile, "r")) {
-                                for (int b = 0; b < numOfBlocks; b++) {
-                                    if (App.blockSequence == BlockSequence.RANDOM) {
-                                        int rLoc = Util.randInt(0, numOfBlocks - 1);
-                                        rAccFile.seek(rLoc * blockSize);
-                                    } else {
-                                        rAccFile.seek(b * blockSize);
-                                    }
-                                    rAccFile.readFully(blockArr, 0, blockSize);
-                                    totalBytesReadInMark += blockSize;
-                                    synchronized (BenchmarkCallable.this) {
-                                        rUnitsComplete[0]++;
-                                        unitsComplete[0] = rUnitsComplete[0] + wUnitsComplete[0];
-                                        float percentComplete = (float)unitsComplete[0] / (float) unitsTotal * 100f;
-                                        int newProgress = (int) percentComplete;
-                                        drawProgressBar(newProgress, unitsTotal);
-                                    }
-                                }
-                            }
-                        } catch (IOException ex) {
-                            Logger.getLogger(BenchmarkCallable.class.getName()).log(Level.SEVERE, null, ex);
-                        }
-                        long endTime = System.nanoTime();
-                        long elapsedTimeNs = endTime - startTime;
-                        sample.accessTimeMs = (elapsedTimeNs / 1_000_000f) / (float) numOfBlocks;
-                        double sec = (double) elapsedTimeNs / 1_000_000_000d;
-                        double mbRead = (double) totalBytesReadInMark / (double) MEGABYTE;
-                        sample.bwMbSec = mbRead / sec;
-                        App.updateMetrics(sample);
-                        if (App.verbose) {
-                            switch (sample.type) {
-                                case WRITE -> System.out.println("w: " + s);
-                                case READ -> System.out.println("r: " + s);
-                            }
-                        }
-                        rOperation.bwMax = sample.cumMax;
-                        rOperation.bwMin = sample.cumMin;
-                        rOperation.bwAvg = sample.cumAvg;
-                        rOperation.accAvg = sample.cumAccTimeMs;
-                        rOperation.add(sample);
-                    }
-                }));
-            }
-            // stop accepting new task
-            executorService.shutdown();
-            // block until all tasks are complete
-            for (Future<?> future : futures) {
-                try {
-                    future.get();
-                } catch (InterruptedException e) {
-                    // Primary benchmark thread interrupted
-                    Thread.currentThread().interrupt(); 
-                    throw e; // Re-throw to stop the benchmark
-                } catch (ExecutionException e) {
-                    Logger.getLogger(BenchmarkCallable.class.getName()).log(Level.SEVERE, "Range thread failed.", e.getCause());
-                    throw new RuntimeException("Benchmark operation failed in worker thread.", e.getCause());
-                }
-            }
-            // GH-10 file IOPS processing
-            rOperation.endTime = LocalDateTime.now();
-            rOperation.setTotalOps(rUnitsComplete[0]);
-            App.rIops = rOperation.iops;
-        }
-        benchmark.endTime = LocalDateTime.now();
+        // Post-benchmark persistence and export
         if (App.autoSave) {
-            EntityManager em = EM.getEntityManager();
-            em.getTransaction().begin();
-            em.persist(benchmark);
-            em.getTransaction().commit();
-            App.benchmarks.put(benchmark.getStartTimeString(), benchmark);
-            for (BenchmarkOperation o : benchmark.getOperations()) {
-                App.operations.put(o.getStartTimeString(), o);
+            try {
+                EntityManager em = EM.getEntityManager();
+                em.getTransaction().begin();
+                em.persist(benchmark);
+                em.getTransaction().commit();
+                App.benchmarks.put(benchmark.getStartTimeString(), benchmark);
+                for (BenchmarkOperation o : benchmark.getOperations()) {
+                    App.operations.put(o.getStartTimeString(), o);
+                }
+            } catch (Exception e) {
+                logger.log(Level.SEVERE, "Failed to save benchmark to DB", e);
             }
         }
-        
-        // process json export if path was set
+
         if (App.exportPath != null) {
             JsonExporter.writeBenchmarkToJson(benchmark, App.exportPath.getAbsolutePath());
         }
-        
+
         App.nextSampleNumber += App.numOfSamples;
         long duration = System.currentTimeMillis() - start;
-        System.out.println();
+        System.out.println(); // Move to new line after progress bar
         System.out.println(App.benchmarkType + " benchmark finished after " + duration + "ms.");
         return benchmark;
     }

--- a/src/jdiskmark/BenchmarkCallable.java
+++ b/src/jdiskmark/BenchmarkCallable.java
@@ -66,9 +66,8 @@ public class BenchmarkCallable implements Callable<Benchmark> {
     @Override
     public Benchmark call() throws Exception {
         // 1. Profile Awareness: Apply "Quick Test" as the default CLI behavior if not specified
-        if (App.activeProfile == BenchmarkProfile.QUICK_TEST) {
-            System.out.println("Applying Quick Test Profile...");
-        }
+        
+        App.loadProfile(BenchmarkProfile.QUICK_TEST);
 
         System.out.println(App.benchmarkType + " benchmark started...");
         long start = System.currentTimeMillis();

--- a/src/jdiskmark/BenchmarkConfig.java
+++ b/src/jdiskmark/BenchmarkConfig.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import java.nio.file.Path;
 import jdiskmark.App.IoEngine;
 import jdiskmark.App.SectorAlignment;
 

--- a/src/jdiskmark/BenchmarkConfig.java
+++ b/src/jdiskmark/BenchmarkConfig.java
@@ -4,6 +4,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import java.nio.file.Path;
+import jdiskmark.App.IoEngine;
+import jdiskmark.App.SectorAlignment;
 
 @Embeddable
 public class BenchmarkConfig {
@@ -31,8 +34,8 @@ public class BenchmarkConfig {
     public int getNumBlocks() { return numBlocks; }
     
     @Column
-    int blockSize = 0;
-    public int getBlockSize() { return blockSize; }
+    long blockSize = 0;
+    public long getBlockSize() { return blockSize; }
     
     @Column
     int numSamples = 0;
@@ -46,12 +49,47 @@ public class BenchmarkConfig {
     int numThreads = 1;
     public int getNumThreads() { return numThreads; }
     
-    // NEW: whether write-sync was enabled for this run (only meaningful for WRITE; may be null for READ)
+    // --- I/O Engine Settings ---
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    IoEngine ioEngine;
+    public IoEngine getIoEngine() { return ioEngine; }
+    public void setIoEngine(IoEngine engine) { ioEngine = engine; }
+
+    @Column
+    Boolean directIoEnabled;
+    public Boolean getDirectIoEnabled() { return directIoEnabled; }
+    public void setDirectIoEnabled(Boolean enable) { directIoEnabled = enable; }
+
     @Column
     Boolean writeSyncEnabled;
     public Boolean getWriteSyncEnabled() { return writeSyncEnabled; }
+    public void setWriteSyncEnabled(Boolean enable) { writeSyncEnabled = enable; }
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    SectorAlignment sectorAlignment;
+    public SectorAlignment getSectorAlignment() { return sectorAlignment; }
+    public void setSectorAlignment(SectorAlignment bytes) { sectorAlignment = bytes; }
+
+    @Column
+    Boolean multiFileEnabled;
+    public Boolean getMultiFileEnabled() { return multiFileEnabled; }
+    public void setMultiFileEnabled(Boolean enable) { multiFileEnabled = enable; }
     
-    public BenchmarkConfig() {
-        appVersion = App.VERSION;
+    @Column
+    String testDir;
+    public String getTestDir() { return testDir; }
+    public void setTestDir(String testDir) { this.testDir = testDir; }
+    
+    public BenchmarkConfig() {}
+    
+    public boolean hasReadOperation() {
+        return benchmarkType == Benchmark.BenchmarkType.READ || benchmarkType == Benchmark.BenchmarkType.READ_WRITE;
+    }
+
+    public boolean hasWriteOperation() {
+        return benchmarkType == Benchmark.BenchmarkType.WRITE || benchmarkType == Benchmark.BenchmarkType.READ_WRITE;
     }
 }

--- a/src/jdiskmark/BenchmarkControlPanel.java
+++ b/src/jdiskmark/BenchmarkControlPanel.java
@@ -16,17 +16,17 @@ public class BenchmarkControlPanel extends JPanel {
 
     final Font HEADER_FONT = new JLabel().getFont().deriveFont(Font.BOLD);
     final Integer[] THREAD_OPTIONS = {1,2,4,8,16,32};
-    final Integer[] BLOCK_OPTIONS = {1,2,4,8,16,32,64,128,256,512,1024,2048};
+    final Integer[] NUM_BLOCK_OPTIONS = {1,2,4,8,16,32,64,128,256,512,1024,2048};
     final Integer[] BLOCK_SIZES = {1,2,4,8,16,32,64,128,256,512,1024,2048};
-    final Integer[] SAMPLE_OPTIONS = {25,50,100,200,300,500,1000,2000,3000,5000,10000};
+    final Integer[] NUM_SAMPLE_OPTIONS = {25,50,100,200,300,500,1000,2000,3000,5000,10000};
     
     public JComboBox<BenchmarkProfile> profileCombo = new JComboBox<>(BenchmarkProfile.getDefaults());
     public JComboBox<Benchmark.BenchmarkType> typeCombo = new JComboBox<>(Benchmark.BenchmarkType.values());
     public JComboBox<Integer> numThreadsCombo = new JComboBox<>(THREAD_OPTIONS);
     public JComboBox<Benchmark.BlockSequence> orderCombo = new JComboBox<>(Benchmark.BlockSequence.values());
-    public JComboBox<Integer> numBlocksCombo = new JComboBox<>(BLOCK_OPTIONS);
+    public JComboBox<Integer> numBlocksCombo = new JComboBox<>(NUM_BLOCK_OPTIONS);
     public JComboBox<Integer> blockSizeCombo = new JComboBox<>(BLOCK_SIZES);
-    public JComboBox<Integer> numSamplesCombo = new JComboBox<>(SAMPLE_OPTIONS);
+    public JComboBox<Integer> numSamplesCombo = new JComboBox<>(NUM_SAMPLE_OPTIONS);
     
     public JButton startButton = new JButton("Start");
     
@@ -59,26 +59,7 @@ public class BenchmarkControlPanel extends JPanel {
             
             if (profile == null) return;
             
-            App.activeProfile = profile;
-            
-            // skip adjustments if custom test was selected
-            if (profile.equals(BenchmarkProfile.CUSTOM_TEST)) {
-                return;
-            }
-            
-            // TODO: later relocate into a BenchmarkConfiguration.java
-            App.benchmarkType = profile.getBenchmarkType();
-            App.blockSequence = profile.getBlockSequence();
-            App.numOfThreads = profile.getNumThreads();
-            App.numOfSamples = profile.getNumSamples();
-            App.numOfBlocks = profile.getNumBlocks();
-            App.blockSizeKb = profile.getBlockSizeKb();
-            App.ioEngine = profile.getIoEngine();
-            App.directEnable = profile.isDirectEnable();
-            App.writeSyncEnable = profile.isWriteSyncEnable();
-            App.sectorAlignment = profile.getSectorAlignment();
-            App.multiFile = profile.isMultiFile();
-            App.saveConfig();
+            App.loadProfile(profile);
             
             // only if initialized, calls our refresh
             if (Gui.mainFrame != null) {
@@ -163,12 +144,12 @@ public class BenchmarkControlPanel extends JPanel {
     
     private void initComponents() {
         
-        // Make numeric combos editable
-        //todo add input guard against non numerics
-        numThreadsCombo.setEditable(true);
-        numBlocksCombo.setEditable(true);
-        blockSizeCombo.setEditable(true);
-        numSamplesCombo.setEditable(true);
+        // editable combos are a workaround to loading non selectable values
+        // to use this need to add input guard against non numerics
+//        numThreadsCombo.setEditable(true);
+//        numBlocksCombo.setEditable(true);
+//        blockSizeCombo.setEditable(true);
+//        numSamplesCombo.setEditable(true);
         
         // 3 column layout framework
         setLayout(new MigLayout("insets 0 5 0 5, fillx, wrap 3", "[30%][27%][43%]", "[]10[]"));

--- a/src/jdiskmark/BenchmarkControlPanel.java
+++ b/src/jdiskmark/BenchmarkControlPanel.java
@@ -56,6 +56,9 @@ public class BenchmarkControlPanel extends JPanel {
             if (!profileCombo.hasFocus()) { return; }
             
             BenchmarkProfile profile = (BenchmarkProfile)profileCombo.getSelectedItem();
+            
+            if (profile == null) return;
+            
             App.activeProfile = profile;
             
             // skip adjustments if custom test was selected
@@ -159,6 +162,13 @@ public class BenchmarkControlPanel extends JPanel {
     }
     
     private void initComponents() {
+        
+        // Make numeric combos editable
+        //todo add input guard against non numerics
+        numThreadsCombo.setEditable(true);
+        numBlocksCombo.setEditable(true);
+        blockSizeCombo.setEditable(true);
+        numSamplesCombo.setEditable(true);
         
         // 3 column layout framework
         setLayout(new MigLayout("insets 0 5 0 5, fillx, wrap 3", "[30%][27%][43%]", "[]10[]"));

--- a/src/jdiskmark/BenchmarkControlPanel.java
+++ b/src/jdiskmark/BenchmarkControlPanel.java
@@ -75,8 +75,9 @@ public class BenchmarkControlPanel extends JPanel {
             App.writeSyncEnable = profile.isWriteSyncEnable();
             App.sectorAlignment = profile.getSectorAlignment();
             App.multiFile = profile.isMultiFile();
+            App.saveConfig();
             
-            // only signal if initialized
+            // only if initialized, calls our refresh
             if (Gui.mainFrame != null) {
                 Gui.mainFrame.refreshConfig();
             }

--- a/src/jdiskmark/BenchmarkLogic.java
+++ b/src/jdiskmark/BenchmarkLogic.java
@@ -1,0 +1,234 @@
+package jdiskmark;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static jdiskmark.App.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+import jdiskmark.Benchmark.IOMode;
+
+public class BenchmarkLogic {
+    
+    // Listener interface to decouple from Swing/CLI
+    public interface BenchmarkListener {
+        void onSampleComplete(Sample sample);
+        void onProgressUpdate(long completed, long total);
+        boolean isCancelled();
+        void requestCacheDrop();
+    }
+    
+    @FunctionalInterface
+    private interface IOAction {
+        void perform(Sample sample) throws Exception;
+    }
+
+    // Minimum milliseconds between progress updates to avoid excessive UI refreshes
+    private static final long UPDATE_INTERVAL = 25;
+    
+    private static final Logger logger = Logger.getLogger(BenchmarkLogic.class.getName());
+    
+    final BenchmarkListener listener;
+    final AtomicLong lastUpdateMs = new AtomicLong(0);
+    final LongAdder writeUnitsComplete = new LongAdder();
+    final LongAdder readUnitsComplete = new LongAdder();
+    int unitsTotal;
+    int blockSize;
+    byte[] blockArr; // for legacy jdk io
+
+    public static int[][] divideIntoRanges(int startIndex, int endIndex, int numThreads) {
+        if (numThreads <= 0 || endIndex < startIndex) {
+            return new int[0][0]; // Handle invalid input
+        }
+
+        int numElements = endIndex - startIndex; // Calculate the total number of elements
+        int[][] ranges = new int[numThreads][2];
+        int rangeSize = numElements / numThreads;
+        int remainder = numElements % numThreads;
+        int start = startIndex;
+
+        for (int i = 0; i < numThreads; i++) {
+            int end = start + rangeSize;
+            if (remainder > 0) {
+                end++; // Distribute the remainder
+                remainder--;
+            }
+            ranges[i][0] = start;
+            ranges[i][1] = end;
+            start = end;
+        }
+        return ranges;
+    }
+    
+    public BenchmarkLogic(BenchmarkListener listener) {
+        this.listener = listener;
+    }
+
+    public Benchmark execute() throws Exception {
+        // 1. Setup metadata
+        int wUnitsTotal = isWriteEnabled() ? numOfBlocks * numOfSamples : 0;
+        int rUnitsTotal = isReadEnabled() ? numOfBlocks * numOfSamples : 0;
+        unitsTotal = wUnitsTotal + rUnitsTotal;
+        blockSize = blockSizeKb * KILOBYTE;
+        
+        if (ioEngine == IoEngine.LEGACY) {
+            blockArr = new byte[blockSize];
+            for (int b = 0; b < blockArr.length; b++) {
+                if (b % 2 == 0) blockArr[b] = (byte) 0xFF;
+            }
+        }
+
+        String driveModel = Util.getDriveModel(locationDir);
+        String partitionId = Util.getPartitionId(locationDir.toPath());
+        DiskUsageInfo usageInfo = Util.getDiskUsage(locationDir.toString());
+
+        // 2. Initialize Benchmark Object
+        Benchmark benchmark = new Benchmark(benchmarkType);
+        mapSystemInfo(benchmark, driveModel, partitionId, usageInfo);
+
+        int[][] tRanges = divideIntoRanges(nextSampleNumber, nextSampleNumber + numOfSamples, numOfThreads);
+
+        // 3. Execution Loops
+        if (isWriteEnabled()) {
+            runOperation(benchmark, Benchmark.IOMode.WRITE, tRanges, blockSize, blockArr, unitsTotal);
+        }
+        
+        if (isReadEnabled() && isWriteEnabled() && !listener.isCancelled()) {
+            throttledProgressUpdate(true);
+            listener.requestCacheDrop();
+        }
+
+        if (isReadEnabled()) {
+            runOperation(benchmark, IOMode.READ, tRanges, blockSize, blockArr, unitsTotal);
+        }
+
+        benchmark.endTime = LocalDateTime.now();
+        return benchmark;
+    }
+
+    private void runOperation(Benchmark b, IOMode mode, int[][] ranges, int blockSize, byte[] blockArr, int total) throws Exception {
+        BenchmarkOperation op = createOp(b, mode);
+        ExecutorService executor = Executors.newFixedThreadPool(numOfThreads);
+        List<Future<?>> futures = new ArrayList<>();
+
+        final IOAction action;
+        if (ioEngine == IoEngine.LEGACY) {
+            if (mode == IOMode.WRITE) {
+                action = (s) -> s.measureWriteLegacy(blockSize, numOfBlocks, blockArr, this);
+            } else {
+                action = (s) -> s.measureReadLegacy(blockSize, numOfBlocks, blockArr, this);
+            }
+        } else {
+            if (mode == IOMode.WRITE) {
+                action = (s) -> s.measureWrite(blockSize, numOfBlocks, this);
+            } else {
+                action = (s) -> s.measureRead(blockSize, numOfBlocks, this);
+            }
+        }
+        
+        for (int[] range : ranges) {
+            futures.add(executor.submit(() -> {
+                for (int s = range[0]; s < range[1] && !listener.isCancelled(); s++) {
+                    Sample.Type type = mode == IOMode.WRITE ? Sample.Type.WRITE : Sample.Type.READ;
+                    Sample sample = new Sample(type, s);
+                    try {
+                        action.perform(sample);
+                    } catch (Exception ex) {
+                        Logger.getLogger(BenchmarkLogic.class.getName()).log(Level.SEVERE, null, ex);
+                        throw new RuntimeException(ex);
+                    }
+                    
+                    updateMetrics(sample);
+                    // Update op-level cumulative stats
+                    op.bwMax = sample.cumMax;
+                    op.bwMin = sample.cumMin;
+                    op.bwAvg = sample.cumAvg;
+                    op.accAvg = sample.cumAccTimeMs;
+                    op.add(sample);
+                    
+                    if (mode == IOMode.WRITE) writeUnitsComplete.increment();
+                    else readUnitsComplete.increment();
+                    
+                    listener.onSampleComplete(sample);
+                    throttledProgressUpdate(false);
+                }
+            }));
+        }
+        executor.shutdown();
+        try {
+            for (Future<?> f : futures) f.get(); // Wait and propagate exceptions
+        } catch (ExecutionException e) {
+            throw new Exception("Threaded IO operation failed", e.getCause());
+        } finally {
+            op.endTime = LocalDateTime.now();
+            op.setTotalOps(mode == IOMode.WRITE ? writeUnitsComplete.sum() : readUnitsComplete.sum());
+            if (op.ioMode == IOMode.WRITE) App.wIops = op.iops;
+            else App.rIops = op.iops;
+        }
+    }
+    
+    public void throttledProgressUpdate(boolean forceUpdate) {
+        long currentTime = System.currentTimeMillis();
+        long lastTime = lastUpdateMs.get();
+        long elapsedTime = currentTime - lastTime;
+        
+        // Aggregate from LongAdders (Thread-safe, no sync needed)
+        long totalCompleted = writeUnitsComplete.sum() + readUnitsComplete.sum();
+        float percentComplete = (float)totalCompleted / (float) unitsTotal * 100f;
+        int newProgress = (int)percentComplete;
+        if (elapsedTime >= UPDATE_INTERVAL || forceUpdate) {
+            if (lastUpdateMs.compareAndSet(lastTime, currentTime) || forceUpdate) {
+                // Clamp value to Swing limits
+                int clampedProgress = Math.min(100, Math.max(0, newProgress));
+                if (listener != null) {
+                    listener.onProgressUpdate(clampedProgress, 100);
+                }
+            }
+        }
+    }
+    
+    public void updateWriteProgress() {
+        writeUnitsComplete.increment();
+        throttledProgressUpdate(false);
+    }
+    
+    public void updateReadProgress() {
+        readUnitsComplete.increment();
+        throttledProgressUpdate(false);
+    }
+    
+    // Helper methods for mapping metadata omitted for brevity...
+    private BenchmarkOperation createOp(Benchmark b, IOMode mode) {
+        BenchmarkOperation op = new BenchmarkOperation();
+        op.setBenchmark(b);
+        op.ioMode = mode;
+        op.blockOrder = blockSequence;
+        op.numSamples = numOfSamples;
+        op.numBlocks = numOfBlocks;
+        op.blockSize = blockSizeKb;
+        op.txSize = targetTxSizeKb();
+        op.numThreads = numOfThreads;
+        if (mode == IOMode.WRITE) {
+            op.setWriteSyncEnabled(writeSyncEnable);
+        }
+        b.getOperations().add(op);
+        return op;
+    }
+    
+    private void mapSystemInfo(Benchmark b, String model, String partId, DiskUsageInfo u) {
+        b.systemInfo.processorName = processorName;
+        b.systemInfo.os = os;
+        b.systemInfo.arch = arch;
+        b.systemInfo.jdk = jdk;
+        b.systemInfo.locationDir = locationDir.toString();
+        
+        b.driveInfo.driveModel = model;
+        b.driveInfo.partitionId = partId;
+        b.driveInfo.percentUsed = u.percentUsed;
+        b.driveInfo.usedGb = u.usedGb;
+        b.driveInfo.totalGb = u.totalGb;
+    }
+}

--- a/src/jdiskmark/BenchmarkOperation.java
+++ b/src/jdiskmark/BenchmarkOperation.java
@@ -63,8 +63,8 @@ public class BenchmarkOperation implements Serializable {
     int numBlocks = 0;
     public int getNumBlocks() { return numBlocks; }
     @Column
-    int blockSize = 0;
-    public int getBlockSize() { return blockSize; }
+    long blockSize = 0;
+    public long getBlockSize() { return blockSize; }
     @Column
     int numSamples = 0;
     public int getNumSamples() { return numSamples; }

--- a/src/jdiskmark/BenchmarkProfile.java
+++ b/src/jdiskmark/BenchmarkProfile.java
@@ -126,6 +126,22 @@ public enum BenchmarkProfile {
             false // Exporting to a single container file
     ),
     
+    // --- 8. Photo Library (Small-to-Medium Random Read) ---
+    PHOTO_LIBRARY(
+            "Photo Library", 
+            BenchmarkType.READ, 
+            BlockSequence.RANDOM, 
+            8,    // High threading for thumbnail generation
+            1000, // Large sample size (from your list)
+            8,    // Low block count per file (from your list)
+            128,  // 128KB typical preview size
+            IoEngine.MODERN, 
+            true, // Direct IO
+            false,
+            SectorAlignment.ALIGN_4K,
+            true  // Multi-file is vital for this use case
+    ),
+    
     // --- Custom (option indicator, not actual profile) ---
     CUSTOM_TEST(
         "Custom Test", BenchmarkType.READ_WRITE, 
@@ -187,6 +203,7 @@ public enum BenchmarkProfile {
             MAX_WRITE_STRESS,
             MEDIA_PLAYBACK,
             VIDEO_EXPORTING,
+            PHOTO_LIBRARY,
             CUSTOM_TEST
         ).toArray(BenchmarkProfile[]::new);
     }

--- a/src/jdiskmark/BenchmarkProfile.java
+++ b/src/jdiskmark/BenchmarkProfile.java
@@ -21,7 +21,7 @@ public enum BenchmarkProfile {
             BlockSequence.SEQUENTIAL,
             1,  // threads
             50, // samples
-            25, // blocks
+            32, // blocks
             1024, // blk size kb
             IoEngine.LEGACY, // jdk io
             false, // direct io
@@ -30,14 +30,14 @@ public enum BenchmarkProfile {
             false // multiFile
     ),
     
-    // --- 2. Max Sequential Speed (Peak Throughput) ---
-    MAX_SEQUENTIAL_SPEED(
-            "Max Sequential Speed", 
+    // --- 2. Peak Throughput (marketing specs) ---
+    MAX_THROUGHPUT(
+            "Max Throughput", 
             BenchmarkType.READ_WRITE, 
             BlockSequence.SEQUENTIAL, 
             1,   // threads
             100, // samples
-            200, // blocks
+            256, // blocks
             1024, // blk size kb
             IoEngine.MODERN, // jdk io
             true, // direct io
@@ -46,14 +46,14 @@ public enum BenchmarkProfile {
             false // multiFile
     ),
 
-    // --- 3. High-Load Random (T32 Proxy / Max IOPS) ---
+    // --- 3. High-Load Random (T32 / Max IOPS) ---
     HIGH_LOAD_RANDOM_T32(
             "Random 4K (T32)", 
             BenchmarkType.READ_WRITE, 
             BlockSequence.RANDOM, 
             32,  // threads 
             200, // samples
-            100, // blocks
+            128, // blocks
             4, // blk size kb
             IoEngine.MODERN, // jdk io
             true, // direct io
@@ -69,7 +69,7 @@ public enum BenchmarkProfile {
             BlockSequence.RANDOM, 
             1,   // thread
             150, // samples
-            50,  // blocks
+            64,  // blocks
             4, // blk size kb
             IoEngine.LEGACY, // jdk io
             false, // direct io
@@ -85,7 +85,7 @@ public enum BenchmarkProfile {
             BlockSequence.SEQUENTIAL, 
             4,   // thread 
             250, // samples
-            500, // blocks
+            512, // blocks
             512, // blk size kb
             IoEngine.MODERN, // jdk io
             true, // direct io
@@ -93,8 +93,40 @@ public enum BenchmarkProfile {
             SectorAlignment.ALIGN_4K,
             true // multiFile
     ),
+    
+    // --- 6. Media Playback (Consumer/Viewer Use Case) ---
+    MEDIA_PLAYBACK(
+            "Media Playback",
+            BenchmarkType.READ, 
+            BlockSequence.SEQUENTIAL, 
+            1,    // single thread for linear playback
+            300,  // samples (from your list)
+            256,  // blocks (from your list)
+            2048, // 2MB block size for high-bitrate simulation
+            IoEngine.MODERN, 
+            true, // direct io (bypass cache)
+            false,// writeSync (unnecessary for media)
+            SectorAlignment.ALIGN_4K,
+            false // Single large file is more realistic for movies
+    ),
 
-    // --- 6. Custom (option indicator, not actual profile) ---
+    // --- 7. Content Creation (Sustained Sequential Write) ---
+    VIDEO_EXPORTING(
+            "Video Exporting", 
+            BenchmarkType.WRITE, 
+            BlockSequence.SEQUENTIAL, 
+            4,    // Parallel chunks from the encoder
+            500,  // samples (from your list)
+            128,  // blocks (from your list)
+            1024, // 1MB block size
+            IoEngine.MODERN, 
+            true, // direct io
+            false,// writeSync (OS handles buffering)
+            SectorAlignment.ALIGN_4K,
+            false // Exporting to a single container file
+    ),
+    
+    // --- Custom (option indicator, not actual profile) ---
     CUSTOM_TEST(
         "Custom Test", BenchmarkType.READ_WRITE, 
         BlockSequence.SEQUENTIAL, 1, 1, 1, 1,
@@ -149,10 +181,12 @@ public enum BenchmarkProfile {
 
     public static BenchmarkProfile[] getDefaults() {
         return List.of(QUICK_TEST,
-            MAX_SEQUENTIAL_SPEED,
+            MAX_THROUGHPUT,
             HIGH_LOAD_RANDOM_T32,
             LOW_LOAD_RANDOM_T1,
             MAX_WRITE_STRESS,
+            MEDIA_PLAYBACK,
+            VIDEO_EXPORTING,
             CUSTOM_TEST
         ).toArray(BenchmarkProfile[]::new);
     }

--- a/src/jdiskmark/BenchmarkRunner.java
+++ b/src/jdiskmark/BenchmarkRunner.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 import jdiskmark.Benchmark.IOMode;
 
-public class BenchmarkLogic {
+public class BenchmarkRunner {
     
     // Listener interface to decouple from Swing/CLI
     public interface BenchmarkListener {
@@ -29,7 +29,7 @@ public class BenchmarkLogic {
     // Minimum milliseconds between progress updates to avoid excessive UI refreshes
     private static final long UPDATE_INTERVAL = 25;
     
-    private static final Logger logger = Logger.getLogger(BenchmarkLogic.class.getName());
+    private static final Logger logger = Logger.getLogger(BenchmarkRunner.class.getName());
     
     final BenchmarkListener listener;
     final AtomicLong lastUpdateMs = new AtomicLong(0);
@@ -63,7 +63,7 @@ public class BenchmarkLogic {
         return ranges;
     }
     
-    public BenchmarkLogic(BenchmarkListener listener) {
+    public BenchmarkRunner(BenchmarkListener listener) {
         this.listener = listener;
     }
 
@@ -137,7 +137,7 @@ public class BenchmarkLogic {
                     try {
                         action.perform(sample);
                     } catch (Exception ex) {
-                        Logger.getLogger(BenchmarkLogic.class.getName()).log(Level.SEVERE, null, ex);
+                        Logger.getLogger(BenchmarkRunner.class.getName()).log(Level.SEVERE, null, ex);
                         throw new RuntimeException(ex);
                     }
                     

--- a/src/jdiskmark/BenchmarkRunner.java
+++ b/src/jdiskmark/BenchmarkRunner.java
@@ -73,8 +73,8 @@ public class BenchmarkRunner {
     }
 
     public Benchmark execute() throws Exception {
-        long wUnitsTotal = config.hasWriteOperation() ? config.numBlocks * config.numSamples : 0;
-        long rUnitsTotal = config.hasReadOperation() ? config.numBlocks * config.numSamples : 0;
+        long wUnitsTotal = config.hasWriteOperation() ? (long) config.numBlocks * config.numSamples : 0L;
+        long rUnitsTotal = config.hasReadOperation() ? (long) config.numBlocks * config.numSamples : 0L;
         unitsTotal = wUnitsTotal + rUnitsTotal;
         blockSize = config.blockSize;
         

--- a/src/jdiskmark/BenchmarkRunner.java
+++ b/src/jdiskmark/BenchmarkRunner.java
@@ -157,8 +157,8 @@ public class BenchmarkRunner {
                     op.add(sample);
                     
                     switch (mode) {
-                        case WRITE: writeUnitsComplete.increment();
-                        case READ: readUnitsComplete.increment();
+                        case WRITE -> writeUnitsComplete.increment();
+                        case READ -> readUnitsComplete.increment();
                     }
                     
                     listener.onSampleComplete(sample);

--- a/src/jdiskmark/BenchmarkWorker.java
+++ b/src/jdiskmark/BenchmarkWorker.java
@@ -1,105 +1,20 @@
 package jdiskmark;
 // constants
-import static jdiskmark.App.KILOBYTE;
-import static jdiskmark.Benchmark.IOMode;
 import static jdiskmark.Sample.Type.READ;
 import static jdiskmark.Sample.Type.WRITE;
 // global variables
-import static jdiskmark.App.blockSizeKb;
-import static jdiskmark.App.ioEngine;
-import static jdiskmark.App.locationDir;
 import static jdiskmark.App.msg;
-import static jdiskmark.App.numOfBlocks;
-import static jdiskmark.App.numOfSamples;
 import static jdiskmark.App.dataDir;
 
 import jakarta.persistence.EntityManager;
-import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.LongAdder;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.swing.SwingWorker;
-import jdiskmark.App.IoEngine;
 
 /**
  * Thread running the disk benchmarking. only one of these threads can run at
  * once.
  */
 public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
-
-    // Minimum milliseconds between progress updates to avoid excessive UI refreshes
-    private static final long UPDATE_INTERVAL = 25;
-    private final AtomicLong lastUpdateMs = new AtomicLong(0);
-
-    Benchmark benchmark;
-    
-    // GH-20 final to aid w lambda usage
-    private final LongAdder writeUnitsComplete = new LongAdder();
-    private final LongAdder readUnitsComplete = new LongAdder();
-    
-    int unitsTotal;
-    int blockSize;
-    byte[] blockArr; // for legacy jdk io
-    
-    public static int[][] divideIntoRanges(int startIndex, int endIndex, int numThreads) {
-        if (numThreads <= 0 || endIndex < startIndex) {
-            return new int[0][0]; // Handle invalid input
-        }
-
-        int numElements = endIndex - startIndex; // Calculate the total number of elements
-        int[][] ranges = new int[numThreads][2];
-        int rangeSize = numElements / numThreads;
-        int remainder = numElements % numThreads;
-        int start = startIndex;
-
-        for (int i = 0; i < numThreads; i++) {
-            int end = start + rangeSize;
-            if (remainder > 0) {
-                end++; // Distribute the remainder
-                remainder--;
-            }
-            ranges[i][0] = start;
-            ranges[i][1] = end;
-            start = end;
-        }
-        return ranges;
-    }
-
-    public void throttledProgressUpdate(boolean forceUpdate) {
-        long currentTime = System.currentTimeMillis();
-        long lastTime = lastUpdateMs.get();
-        long elapsedTime = currentTime - lastTime;
-        
-        // Aggregate from LongAdders (Thread-safe, no sync needed)
-        long totalCompleted = writeUnitsComplete.sum() + readUnitsComplete.sum();
-        float percentComplete = (float)totalCompleted / (float) unitsTotal * 100f;
-        int newProgress = (int)percentComplete;
-        if (elapsedTime >= UPDATE_INTERVAL || forceUpdate) {
-            if (lastUpdateMs.compareAndSet(lastTime, currentTime) || forceUpdate) {
-                // Clamp value to Swing limits
-                int clampedProgress = Math.min(100, Math.max(0, newProgress));
-                setProgress(clampedProgress);
-            }
-        }
-    }
-    
-    public void updateWriteProgress() {
-        writeUnitsComplete.increment();
-        throttledProgressUpdate(false);
-    }
-    
-    public void updateReadProgress() {
-        readUnitsComplete.increment();
-        throttledProgressUpdate(false);
-    }
     
     @Override
     protected Benchmark doInBackground() throws Exception {
@@ -112,18 +27,6 @@ public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
                     + App.blockSequence);
         }
 
-        int wUnitsTotal = App.isWriteEnabled() ? numOfBlocks * numOfSamples : 0;
-        int rUnitsTotal = App.isReadEnabled() ? numOfBlocks * numOfSamples : 0;
-        unitsTotal = wUnitsTotal + rUnitsTotal;
-        blockSize = blockSizeKb * KILOBYTE;
-        if (ioEngine == IoEngine.LEGACY) {
-            blockArr = new byte[blockSize];
-            for (int b = 0; b < blockArr.length; b++) {
-                if (b % 2 == 0) {
-                    blockArr[b] = (byte) 0xFF;
-                }
-            }
-        }
         Gui.updateLegendAndAxis();
 
         if (App.autoReset == true) {
@@ -131,186 +34,28 @@ public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
             Gui.resetBenchmarkData();
             Gui.updateLegendAndAxis();
         }
-
-        String driveModel = Util.getDriveModel(locationDir);
-        String partitionId = Util.getPartitionId(locationDir.toPath());
-        DiskUsageInfo usageInfo = new DiskUsageInfo(); // init to prevent null ref
-        try {
-            usageInfo = Util.getDiskUsage(locationDir.toString());
-        } catch (IOException | InterruptedException ex) {
-            Logger.getLogger(BenchmarkWorker.class.getName()).log(Level.SEVERE, null, ex);
-        }
-        if (App.verbose) {
-            msg("drive model=" + driveModel + " partitionId=" + partitionId
-                    + " usage=" + usageInfo.toDisplayString());
-        }
         
-        // GH-20 calculate ranges for concurrent thread IO
-        int sIndex = App.nextSampleNumber;
-        int eIndex = sIndex + numOfSamples;
-        int[][] tRanges = divideIntoRanges(sIndex, eIndex, App.numOfThreads);
+        BenchmarkLogic.BenchmarkListener listener = new BenchmarkLogic.BenchmarkListener() {
+            @Override
+            public void onSampleComplete(Sample s) { publish(s); }
 
-        // configure the benchmark
-        benchmark = new Benchmark(App.benchmarkType);
-        // system info
-        benchmark.systemInfo.processorName = App.processorName;
-        benchmark.systemInfo.os = App.os;
-        benchmark.systemInfo.arch = App.arch;
-        benchmark.systemInfo.jdk = App.jdk;
-        benchmark.systemInfo.locationDir = App.locationDir.toString();
-        // drive information
-        benchmark.driveInfo.driveModel = driveModel;
-        benchmark.driveInfo.partitionId = partitionId;
-        benchmark.driveInfo.percentUsed = usageInfo.percentUsed;
-        benchmark.driveInfo.usedGb = usageInfo.usedGb;
-        benchmark.driveInfo.totalGb = usageInfo.totalGb;
+            @Override
+            public void onProgressUpdate(long completed, long total) { setProgress((int) completed); }
+
+            @Override
+            public boolean isCancelled() { return BenchmarkWorker.this.isCancelled(); }
+
+            @Override
+            public void requestCacheDrop() { Gui.dropCache(); }
+        };
+
+        BenchmarkLogic logic = new BenchmarkLogic(listener);
+        Benchmark benchmark = logic.execute();
         
         // update gui title
         Gui.chart.getTitle().setText(benchmark.getDriveInfoDisplay());
         Gui.chart.getTitle().setVisible(true);
-        
-        if (App.isWriteEnabled()) {
-            BenchmarkOperation wOperation = new BenchmarkOperation();
-            wOperation.setBenchmark(benchmark);
-            wOperation.ioMode = IOMode.WRITE;
-            wOperation.blockOrder = App.blockSequence;
-            wOperation.numSamples = App.numOfSamples;
-            wOperation.numBlocks = App.numOfBlocks;
-            wOperation.blockSize = App.blockSizeKb;
-            wOperation.txSize = App.targetTxSizeKb();
-            wOperation.numThreads = App.numOfThreads;
-            // persist whether write sync was enabled for this run
-            wOperation.setWriteSyncEnabled(App.writeSyncEnable);
-            benchmark.getOperations().add(wOperation);
 
-            // GH-20 instantiate threads to operate on each range
-            ExecutorService executorService = Executors.newFixedThreadPool(App.numOfThreads);
-            List<Future<?>> futures = new ArrayList<>();
-
-            for (int[] range : tRanges) {
-                final int startSample = range[0];
-                final int endSample = range[1];
-                // submit inline range task thread
-                futures.add(executorService.submit(() -> {
-
-                    for (int s = startSample; s < endSample && !isCancelled(); s++) {
-                        
-                        Sample sample = new Sample(WRITE, s);
-                        if (ioEngine == IoEngine.LEGACY) {
-                            sample.measureWriteLegacy(blockSize, numOfBlocks, blockArr, this);
-                        } else {
-                            sample.measureWrite(blockSize, numOfBlocks, this);
-                        }
-                        
-                        // calculate the sample statistics and store in sample
-                        App.updateMetrics(sample);
-                        publish(sample);
-
-                        wOperation.bwMax = sample.cumMax;
-                        wOperation.bwMin = sample.cumMin;
-                        wOperation.bwAvg = sample.cumAvg;
-                        wOperation.accAvg = sample.cumAccTimeMs;
-                        wOperation.add(sample);
-                    }
-                }));
-            }
-
-            executorService.shutdown(); // stop accepting new task
-            // block until all tasks are complete
-            for (Future<?> future : futures) {
-                try {
-                    future.get();
-                } catch (InterruptedException e) {
-                    // The primary benchmark thread was interrupted
-                    Thread.currentThread().interrupt(); 
-                    throw e; // Re-throw to stop the benchmark
-                } catch (ExecutionException e) {
-                    Logger.getLogger(BenchmarkWorker.class.getName()).log(Level.SEVERE, "Worker range thread failed.", e.getCause());
-                    throw new Exception("Benchmark operation failed in worker thread.", e.getCause());
-                }
-            }
-
-            // GH-10 file IOPS processing
-            wOperation.endTime = LocalDateTime.now();
-            wOperation.setTotalOps(writeUnitsComplete.longValue());
-            App.wIops = wOperation.iops;
-            Gui.controlPanel.refreshWriteMetrics();
-        }
-        
-        // TODO: review renaming all files to clear catch
-        if (App.isReadEnabled() && App.isWriteEnabled() && !isCancelled()) {
-            throttledProgressUpdate(true); // update at the half way point
-            // TODO: review refactor to App.dropCache() & Gui.dropCache()
-            Gui.dropCache();
-        }
-
-        if (App.isReadEnabled()) {
-            BenchmarkOperation rOperation = new BenchmarkOperation();
-            rOperation.setBenchmark(benchmark);
-            // operation parameters
-            rOperation.ioMode = IOMode.READ;
-            rOperation.blockOrder = App.blockSequence;
-            rOperation.numSamples = App.numOfSamples;
-            rOperation.numBlocks = App.numOfBlocks;
-            rOperation.blockSize = App.blockSizeKb;
-            rOperation.txSize = App.targetTxSizeKb();
-            rOperation.numThreads = App.numOfThreads;
-            // write sync does not apply to pure read benchmarks
-            rOperation.setWriteSyncEnabled(null);
-            benchmark.getOperations().add(rOperation);
-
-            ExecutorService executorService = Executors.newFixedThreadPool(App.numOfThreads);
-            List<Future<?>> futures = new ArrayList<>();
-
-            for (int[] range : tRanges) {
-                final int startSample = range[0];
-                final int endSample = range[1];
-
-                futures.add(executorService.submit(() -> {
-                    for (int s = startSample; s < endSample && !isCancelled(); s++) {
-
-                        Sample sample = new Sample(READ, s);
-                        if (ioEngine == IoEngine.LEGACY) {
-                            sample.measureReadLegacy(blockSize, numOfBlocks, blockArr, this);
-                        } else {
-                            sample.measureRead(blockSize, numOfBlocks, this);
-                        }
-                        
-                        // calculate the sample statistics and store in sample
-                        App.updateMetrics(sample);
-                        publish(sample);
-                        
-                        rOperation.bwMax = sample.cumMax;
-                        rOperation.bwMin = sample.cumMin;
-                        rOperation.bwAvg = sample.cumAvg;
-                        rOperation.accAvg = sample.cumAccTimeMs;
-                        rOperation.add(sample);
-                    }
-                }));
-            }
-
-            executorService.shutdown(); // stop accepting new task
-            // block until all tasks are complete
-            for (Future<?> future : futures) {
-                try {
-                    future.get();
-                } catch (InterruptedException ex) {
-                    // primary benchmark thread was interrupted while waiting
-                    Thread.currentThread().interrupt(); 
-                    throw ex; // Re-throw to stop the benchmark
-                } catch (ExecutionException ex) {
-                    Logger.getLogger(BenchmarkWorker.class.getName()).log(Level.SEVERE, "Worker range thread failed.", ex.getCause());
-                    throw new Exception("Benchmark operation failed in worker thread.", ex.getCause());
-                }
-            }
-
-            // GH-10 file IOPS processing
-            rOperation.endTime = LocalDateTime.now();
-            rOperation.setTotalOps(readUnitsComplete.longValue());
-            App.rIops = rOperation.iops;
-            Gui.controlPanel.refreshReadMetrics();
-        }
-        benchmark.endTime = LocalDateTime.now();
         if (App.autoSave) {
             EntityManager em = EM.getEntityManager();
             em.getTransaction().begin();
@@ -345,7 +90,6 @@ public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
 
     @Override
     protected void done() {
-        throttledProgressUpdate(true);
         if (App.autoRemoveData) {
             Util.deleteDirectory(dataDir);
         }

--- a/src/jdiskmark/BenchmarkWorker.java
+++ b/src/jdiskmark/BenchmarkWorker.java
@@ -34,7 +34,7 @@ public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
 
         if (App.verbose) {
             msg("*** starting new worker thread");
-            msg("Running readTest " + App.isReadEnabled() + "   writeTest " + App.isWriteEnabled());
+            msg("Running readTest " + App.hasReadOperation() + "   writeTest " + App.hasWriteOperation());
             msg("num samples: " + App.numOfSamples + ", num blks: " + App.numOfBlocks
                     + ", blk size (kb): " + App.blockSizeKb + ", blockSequence: "
                     + App.blockSequence);
@@ -48,7 +48,7 @@ public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
             Gui.updateLegendAndAxis();
         }
 
-        BenchmarkRunner bRunner = new BenchmarkRunner(listener);
+        BenchmarkRunner bRunner = new BenchmarkRunner(listener, App.getConfig());
         Benchmark benchmark = bRunner.execute();
         
         // update gui title

--- a/src/jdiskmark/BenchmarkWorker.java
+++ b/src/jdiskmark/BenchmarkWorker.java
@@ -15,7 +15,7 @@ import javax.swing.SwingWorker;
  * once.
  */
 public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
-    BenchmarkLogic.BenchmarkListener listener = new BenchmarkLogic.BenchmarkListener() {
+    BenchmarkRunner.BenchmarkListener listener = new BenchmarkRunner.BenchmarkListener() {
         @Override
         public void onSampleComplete(Sample s) { publish(s); }
 
@@ -48,8 +48,8 @@ public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
             Gui.updateLegendAndAxis();
         }
 
-        BenchmarkLogic logic = new BenchmarkLogic(listener);
-        Benchmark benchmark = logic.execute();
+        BenchmarkRunner bRunner = new BenchmarkRunner(listener);
+        Benchmark benchmark = bRunner.execute();
         
         // update gui title
         Gui.chart.getTitle().setText(benchmark.getDriveInfoDisplay());

--- a/src/jdiskmark/BenchmarkWorker.java
+++ b/src/jdiskmark/BenchmarkWorker.java
@@ -15,6 +15,19 @@ import javax.swing.SwingWorker;
  * once.
  */
 public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
+    BenchmarkLogic.BenchmarkListener listener = new BenchmarkLogic.BenchmarkListener() {
+        @Override
+        public void onSampleComplete(Sample s) { publish(s); }
+
+        @Override
+        public void onProgressUpdate(long completed, long total) { setProgress((int) completed); }
+
+        @Override
+        public boolean isCancelled() { return BenchmarkWorker.this.isCancelled(); }
+
+        @Override
+        public void requestCacheDrop() { Gui.dropCache(); }
+    };
     
     @Override
     protected Benchmark doInBackground() throws Exception {
@@ -34,20 +47,6 @@ public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
             Gui.resetBenchmarkData();
             Gui.updateLegendAndAxis();
         }
-        
-        BenchmarkLogic.BenchmarkListener listener = new BenchmarkLogic.BenchmarkListener() {
-            @Override
-            public void onSampleComplete(Sample s) { publish(s); }
-
-            @Override
-            public void onProgressUpdate(long completed, long total) { setProgress((int) completed); }
-
-            @Override
-            public boolean isCancelled() { return BenchmarkWorker.this.isCancelled(); }
-
-            @Override
-            public void requestCacheDrop() { Gui.dropCache(); }
-        };
 
         BenchmarkLogic logic = new BenchmarkLogic(listener);
         Benchmark benchmark = logic.execute();

--- a/src/jdiskmark/Gui.java
+++ b/src/jdiskmark/Gui.java
@@ -266,17 +266,17 @@ public final class Gui {
     }
     
     public static void updateLegendAndAxis() {
-        bwRenderer.setSeriesVisibleInLegend(0, App.isWriteEnabled());
-        bwRenderer.setSeriesVisibleInLegend(1, App.isWriteEnabled());
-        bwRenderer.setSeriesVisibleInLegend(2, App.isWriteEnabled() && showMaxMin);
-        bwRenderer.setSeriesVisibleInLegend(3, App.isWriteEnabled() && showMaxMin);
-        bwRenderer.setSeriesVisibleInLegend(4, App.isReadEnabled());
-        bwRenderer.setSeriesVisibleInLegend(5, App.isReadEnabled());
-        bwRenderer.setSeriesVisibleInLegend(6, App.isReadEnabled() && showMaxMin);
-        bwRenderer.setSeriesVisibleInLegend(7, App.isReadEnabled() && showMaxMin);
+        bwRenderer.setSeriesVisibleInLegend(0, App.hasWriteOperation());
+        bwRenderer.setSeriesVisibleInLegend(1, App.hasWriteOperation());
+        bwRenderer.setSeriesVisibleInLegend(2, App.hasWriteOperation() && showMaxMin);
+        bwRenderer.setSeriesVisibleInLegend(3, App.hasWriteOperation() && showMaxMin);
+        bwRenderer.setSeriesVisibleInLegend(4, App.hasReadOperation());
+        bwRenderer.setSeriesVisibleInLegend(5, App.hasReadOperation());
+        bwRenderer.setSeriesVisibleInLegend(6, App.hasReadOperation() && showMaxMin);
+        bwRenderer.setSeriesVisibleInLegend(7, App.hasReadOperation() && showMaxMin);
 
-        msRenderer.setSeriesVisibleInLegend(0, App.isWriteEnabled() && showDriveAccess);
-        msRenderer.setSeriesVisibleInLegend(1, App.isReadEnabled() && showDriveAccess);
+        msRenderer.setSeriesVisibleInLegend(0, App.hasWriteOperation() && showDriveAccess);
+        msRenderer.setSeriesVisibleInLegend(1, App.hasReadOperation() && showDriveAccess);
         
         msAxis.setVisible(showDriveAccess);
     }
@@ -425,7 +425,7 @@ public final class Gui {
         App.benchmarkType = benchmark.config.benchmarkType;
         App.numOfBlocks = operation.numBlocks;
         App.numOfSamples = operation.numSamples;
-        App.blockSizeKb = operation.blockSize;
+        App.blockSizeKb = (int)(operation.blockSize / App.KILOBYTE);
         App.blockSequence = operation.blockOrder;
         App.numOfThreads = operation.numThreads;
         mainFrame.refreshConfig();

--- a/src/jdiskmark/RunBenchmarkCommand.java
+++ b/src/jdiskmark/RunBenchmarkCommand.java
@@ -22,7 +22,7 @@ public class RunBenchmarkCommand implements Callable<Integer> {
     @Spec 
     CommandLine.Model.CommandSpec spec;
     
-    // --- Profile selction ---
+    // --- Profile selection ---
     
     @Option(names = {"-p", "--profile"},
             description = "Profile: ${COMPLETION-CANDIDATES}. (Default: ${DEFAULT-VALUE})",

--- a/src/jdiskmark/RunBenchmarkCommand.java
+++ b/src/jdiskmark/RunBenchmarkCommand.java
@@ -100,11 +100,6 @@ public class RunBenchmarkCommand implements Callable<Integer> {
                 System.out.println("Benchmark initiated successfully. Need to wait for completion...");
             }
             
-            // 3. Execute the benchmark (You will need to adjust startBenchmark to run without a GUI)
-            // NOTE: The existing App.startBenchmark() relies on a SwingWorker and Gui components.
-            // You MUST refactor the core benchmarking logic out of the SwingWorker and 
-            // into a dedicated CLI execution class/method for this to work.
-            
             try {
                 System.out.print(ANSI_HIDE_CURSOR);
                 App.startBenchmark();

--- a/src/jdiskmark/RunBenchmarkCommand.java
+++ b/src/jdiskmark/RunBenchmarkCommand.java
@@ -3,9 +3,12 @@ package jdiskmark;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import jdiskmark.Benchmark.BenchmarkType;
 import jdiskmark.Benchmark.BlockSequence;
 import jdiskmark.App.IoEngine;
@@ -25,9 +28,20 @@ public class RunBenchmarkCommand implements Callable<Integer> {
     // --- Profile selection ---
     
     @Option(names = {"-p", "--profile"},
-            description = "Profile: ${COMPLETION-CANDIDATES}. (Default: ${DEFAULT-VALUE})",
-            defaultValue = "QUICK_TEST")
+        // This forces the help menu to show the actual Enum constants
+        completionCandidates = ProfileCandidates.class, 
+        description = "Profile: ${COMPLETION-CANDIDATES}. (Default: ${DEFAULT-VALUE})",
+        defaultValue = "QUICK_TEST")
     BenchmarkProfile profile;
+
+    // Helper class to provide the symbols to the help menu
+    static class ProfileCandidates extends ArrayList<String> {
+        ProfileCandidates() { 
+            super(Arrays.stream(BenchmarkProfile.values())
+                        .map(Enum::name)
+                        .collect(Collectors.toList())); 
+        }
+    }
     
     // --- Profile Workload Definition ---
     
@@ -134,6 +148,7 @@ public class RunBenchmarkCommand implements Callable<Integer> {
         }
         try {
             // configure the profile
+            System.out.println("loading profile: " + profile.name);
             App.loadProfile(profile);
             // apply profile parameter overrides
             applyOverrides(spec.commandLine().getParseResult());

--- a/src/jdiskmark/RunBenchmarkCommand.java
+++ b/src/jdiskmark/RunBenchmarkCommand.java
@@ -67,7 +67,7 @@ public class RunBenchmarkCommand implements Callable<Integer> {
             description = "Enable Direct I/O (bypass OS cache). Only works with MODERN engine.")
     boolean directEnable = false;
 
-    @Option(names = {"-s", "--write-sync"},
+    @Option(names = {"-y", "--write-sync"},
             description = "Enable Write Sync (flush to disk).")
     boolean writeSyncEnable = false;
 
@@ -82,13 +82,13 @@ public class RunBenchmarkCommand implements Callable<Integer> {
 
     // --- FLAGS / UTILITY OPTIONS ---
     
-    @Option(names = {"--verbose", "-v"}, description = "Enable detailed logging.")
+    @Option(names = {"-v", "--verbose"}, description = "Enable detailed logging.")
     boolean verbose = false;
 
-    @Option(names = {"--save", "-s"}, description = "Enable saving the benchmark results to the database.")
+    @Option(names = {"-s", "--save"}, description = "Enable saving the benchmark results to the database.")
     boolean save = false;
     
-    @Option(names = {"--clean", "-c"}, description = "Remove existing JDiskMark data directory before starting.")
+    @Option(names = {"-c", "--clean"}, description = "Remove existing JDiskMark data directory before starting.")
     boolean autoRemoveData = false;
 
     @Option(names = {"-h", "--help"}, usageHelp = true, description = "Display this help and exit.")

--- a/src/jdiskmark/RunBenchmarkCommand.java
+++ b/src/jdiskmark/RunBenchmarkCommand.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import jdiskmark.Benchmark.BenchmarkType;
 import jdiskmark.Benchmark.BlockSequence;
 import jdiskmark.App.IoEngine;
+import static jdiskmark.BenchmarkProfile.CUSTOM_TEST;
 import picocli.CommandLine;
 import picocli.CommandLine.Spec;
 
@@ -36,9 +37,10 @@ public class RunBenchmarkCommand implements Callable<Integer> {
 
     // Helper class to provide the symbols to the help menu
     static class ProfileCandidates extends ArrayList<String> {
-        ProfileCandidates() { 
+        ProfileCandidates() {
             super(Arrays.stream(BenchmarkProfile.values())
                         .map(Enum::name)
+                        .filter(name -> !name.equals(CUSTOM_TEST.name()))
                         .collect(Collectors.toList())); 
         }
     }

--- a/src/jdiskmark/RunBenchmarkCommand.java
+++ b/src/jdiskmark/RunBenchmarkCommand.java
@@ -110,7 +110,7 @@ public class RunBenchmarkCommand implements Callable<Integer> {
     @Option(names = {"-v", "--verbose"}, description = "Enable detailed logging.")
     boolean verbose = false;
 
-    // overides to profiles controled parameters
+    // overrides to profile-controlled parameters
     private void applyOverrides(CommandLine.ParseResult pr) {
         // Workload Definition
         if (pr.hasMatchedOption("--type"))         App.benchmarkType = benchmarkType;

--- a/src/jdiskmark/RunBenchmarkCommand.java
+++ b/src/jdiskmark/RunBenchmarkCommand.java
@@ -47,10 +47,17 @@ public class RunBenchmarkCommand implements Callable<Integer> {
     
     // --- Profile Workload Definition ---
     
-    @Option(names = {"-t", "--type"},
+@Option(names = {"-t", "--type"},
+            completionCandidates = TypeCandidates.class,
             description = "Benchmark type: ${COMPLETION-CANDIDATES}. (Profile default used if not specified)",
             defaultValue = "WRITE")
     BenchmarkType benchmarkType;
+
+    static class TypeCandidates extends ArrayList<String> {
+        TypeCandidates() {
+            super(Arrays.stream(BenchmarkType.values()).map(Enum::name).collect(Collectors.toList()));
+        }
+    }
 
     @Option(names = {"-T", "--threads"}, 
             description = "Number of threads to use for testing. (Profile default used if not specified)",
@@ -58,9 +65,16 @@ public class RunBenchmarkCommand implements Callable<Integer> {
     int numOfThreads;
 
     @Option(names = {"-o", "--order"}, 
+            completionCandidates = OrderCandidates.class,
             description = "Block order: ${COMPLETION-CANDIDATES}. (Profile default used if not specified)",
             defaultValue = "SEQUENTIAL")
     BlockSequence blockSequence;
+
+    static class OrderCandidates extends ArrayList<String> {
+        OrderCandidates() {
+            super(Arrays.stream(BlockSequence.values()).map(Enum::name).collect(Collectors.toList()));
+        }
+    }
 
     @Option(names = {"-b", "--blocks"},
             description = "Number of blocks/chunks per sample. (Profile default used if not specified)",
@@ -80,9 +94,16 @@ public class RunBenchmarkCommand implements Callable<Integer> {
     // --- Profile IO Strategy ---
 
     @Option(names = {"-i", "--io-engine"},
+            completionCandidates = EngineCandidates.class,
             description = "I/O Engine: ${COMPLETION-CANDIDATES}. (Profile default used if not specified)",
             defaultValue = "MODERN")
     IoEngine ioEngine;
+
+    static class EngineCandidates extends ArrayList<String> {
+        EngineCandidates() {
+            super(Arrays.stream(IoEngine.values()).map(Enum::name).collect(Collectors.toList()));
+        }
+    }
 
     @Option(names = {"-d", "--direct"},
             description = "Enable Direct I/O (bypass OS cache). Only works with MODERN engine.")
@@ -93,9 +114,16 @@ public class RunBenchmarkCommand implements Callable<Integer> {
     boolean writeSyncEnable = false;
 
     @Option(names = {"-a", "--alignment"},
+            completionCandidates = AlignmentCandidates.class,
             description = "Sector alignment: ${COMPLETION-CANDIDATES}. (Profile default used if not specified)",
             defaultValue = "NONE")
     App.SectorAlignment sectorAlignment;
+
+    static class AlignmentCandidates extends ArrayList<String> {
+        AlignmentCandidates() {
+            super(Arrays.stream(App.SectorAlignment.values()).map(Enum::name).collect(Collectors.toList()));
+        }
+    }
 
     @Option(names = {"-m", "--multi-file"},
             description = "Create a new file for every sample instead of using one large file.")

--- a/src/jdiskmark/Sample.java
+++ b/src/jdiskmark/Sample.java
@@ -129,7 +129,7 @@ public class Sample {
     }
     
     // pre jdk 25 io api
-    public void measureWriteLegacy(int blockSize, int numOfBlocks, byte[] blockArr, BenchmarkWorker worker) {
+    public void measureWriteLegacy(int blockSize, int numOfBlocks, byte[] blockArr, BenchmarkLogic logic) {
         File testFile = getTestFile();
         long startTime = System.nanoTime();
         long totalBytesWrittenInSample = 0;
@@ -145,7 +145,7 @@ public class Sample {
                     }
                     rAccFile.write(blockArr, 0, blockSize);
                     totalBytesWrittenInSample += blockSize;
-                    worker.updateWriteProgress();
+                    logic.updateWriteProgress();
                 }
             }
         } catch (IOException ex) {
@@ -160,7 +160,7 @@ public class Sample {
     }
     
     // pre jdk 25 io api
-    public void measureReadLegacy(int blockSize, int numOfBlocks, byte[] blockArr, BenchmarkWorker worker) {
+    public void measureReadLegacy(int blockSize, int numOfBlocks, byte[] blockArr, BenchmarkLogic logic) {
         File testFile = getTestFile();
         long startTime = System.nanoTime();
         long totalBytesReadInMark = 0;
@@ -175,7 +175,7 @@ public class Sample {
                     }
                     rAccFile.readFully(blockArr, 0, blockSize);
                     totalBytesReadInMark += blockSize;
-                    worker.updateReadProgress();
+                    logic.updateReadProgress();
                 }
             }
         } catch (IOException ex) {
@@ -189,7 +189,7 @@ public class Sample {
         bwMbSec = mbRead / sec;
     }
     
-    public void measureWrite(int blockSize, int numOfBlocks, BenchmarkWorker worker) {
+    public void measureWrite(int blockSize, int numOfBlocks, BenchmarkLogic logic) {
         long totalBytesWritten = 0;
         long finalAlign = sectorAlignment.bytes;
         if (sectorAlignment.bytes <= 0) {
@@ -230,14 +230,14 @@ public class Sample {
         try (FileChannel fc = initialFc; Arena arena = Arena.ofConfined()) {
             MemorySegment segment = arena.allocate(blockSize, finalAlign);
             for (int b = 0; b < numOfBlocks; b++) {
-                if (worker.isCancelled()) break;
+                if (logic.listener.isCancelled()) break;
                 long blockIndex = (blockSequence == RANDOM) ?
                         Util.randInt(0, numOfBlocks - 1) : b;
                 long byteOffset = blockIndex * blockSize;
 
                 int written = fc.write(segment.asByteBuffer(), byteOffset);
                 totalBytesWritten += written;
-                worker.updateWriteProgress();
+                logic.updateWriteProgress();
             }
         } catch (IOException e) {
             Logger.getLogger(Sample.class.getName()).log(Level.SEVERE, null, e);
@@ -248,7 +248,7 @@ public class Sample {
         bwMbSec = (double) totalBytesWritten / (double) MEGABYTE / sec;
     }
     
-    public void measureRead(int blockSize, int numOfBlocks, BenchmarkWorker worker) {
+    public void measureRead(int blockSize, int numOfBlocks, BenchmarkLogic logic) {
         long totalBytesRead = 0;
         File testFile = getTestFile();
         long startTime = System.nanoTime();
@@ -286,12 +286,12 @@ public class Sample {
         try (FileChannel fc = initialFc; Arena arena = Arena.ofConfined()) {
             MemorySegment segment = arena.allocate(blockSize, byteAlignment);
             for (int b = 0; b < numOfBlocks; b++) {
-                if (worker.isCancelled()) break;
+                if (logic.listener.isCancelled()) break;
                 long blockIndex = (blockSequence == RANDOM) ? Util.randInt(0, numOfBlocks - 1) : b;
                 long byteOffset = blockIndex * blockSize;
                 int read = fc.read(segment.asByteBuffer(), byteOffset);
                 totalBytesRead += read;
-                worker.updateReadProgress();
+                logic.updateReadProgress();
             }
         } catch (IOException ex) {
             Logger.getLogger(Sample.class.getName()).log(Level.SEVERE, null, ex);


### PR DESCRIPTION
summary of changes:
1. common benchmark runner extracted from worker and callable. - note: there might be an extra layer of callable still in the cli implementation
2. cli benchmark a) defaults to quick test and allow parameter overrides, b) displays profiles, c) io access options
3. use valid number of blocks setting
4. introduce new profiles for:
    - media playback
    - video export
    - photo library

<img width="1450" height="1226" alt="image" src="https://github.com/user-attachments/assets/7aecd4c4-6e25-455b-bdea-58971d037047" />

potentially a bug on mac w scroll bar rendering

<img width="1472" height="1314" alt="image" src="https://github.com/user-attachments/assets/4ab0e1c9-73f7-491c-97d5-c5a46275956b" />

here is the photo library profile:

<img width="1826" height="1306" alt="image" src="https://github.com/user-attachments/assets/92ddbd1c-b600-45b4-8857-4409237db53c" />
