### PR TITLE
improve progress bar

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,6 +1,5 @@
 annotation.processing.enabled=true
 annotation.processing.enabled.in.editor=false
-annotation.processing.processor.options=-Aeclipselink.canonicalmodel.use_static_factory=false
 annotation.processing.processors.list=
 annotation.processing.run.all.processors=true
 annotation.processing.source.output=${build.generated.sources.dir}/ap-source-output

--- a/src/META-INF/persistence.xml
+++ b/src/META-INF/persistence.xml
@@ -8,8 +8,6 @@
       <property name="jakarta.persistence.jdbc.driver" value="org.apache.derby.jdbc.EmbeddedDriver"/>
       <!-- valid log levels default WARNING, FINE... -->
       <property name="eclipselink.logging.level" value="WARNING"/>
-      <!-- per gemini this is deprecated -->
-      <!--<property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>-->
       <!-- this will drop and create a new db every time, useful for testing -->
       <!--<property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>-->
       <property name="jakarta.persistence.schema-generation.database.action" value="create-or-extend-tables"/>

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -639,7 +639,7 @@ public class App {
     }
     
     public static long targetTxSizeKb() {
-        long operationTxSize = blockSizeKb * numOfBlocks * numOfSamples;
+        long operationTxSize = (long)blockSizeKb * numOfBlocks * numOfSamples;
         if (benchmarkType == BenchmarkType.READ_WRITE
                 || benchmarkType == BenchmarkType.READ) {
             return 2L * operationTxSize;

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -595,33 +595,11 @@ public class App {
         // 6. create data dir if not already present
         if (dataDir.exists() == false) { dataDir.mkdirs(); }
         
-        // 7. start disk worker thread
+        // 7. start benchmark job thread
         switch (mode) {
             case GUI -> {
                 worker = new BenchmarkWorker();
-                // TODO: GH-#135 - progress bar cleanup
-                // 1. look at relocating this into the gui class
-                // 2. we are using the progress bar to track units
-                // instead of transfer io (for read prep)
-                // 3. the number of units or tx bytes should be twice for read
-                // and write operations or read prep and read operations
-                worker.addPropertyChangeListener((final var event) -> {
-                    switch (event.getPropertyName()) {
-                        case "progress" -> {
-                            int value = (Integer)event.getNewValue();
-                            long kbProcessed = value * App.targetTxSizeKb() / 100;
-                            String progressText = String.valueOf(kbProcessed) + " / " + String.valueOf(App.targetTxSizeKb());
-                            Gui.progressBar.setValue(value);
-                            Gui.progressBar.setString(progressText);
-                        }
-                        case "state" -> {
-                            switch ((StateValue)event.getNewValue()) {
-                                case STARTED -> Gui.progressBar.setString("0 / " + String.valueOf(App.targetTxSizeKb()));
-                                case DONE -> {}
-                            } // end inner switch
-                        }
-                    }
-                });
+                worker.addPropertyChangeListener(new Gui.WorkerProgressListener());
                 worker.execute();
             }
             case CLI -> {
@@ -661,7 +639,12 @@ public class App {
     }
     
     public static long targetTxSizeKb() {
-        return blockSizeKb * numOfBlocks * numOfSamples;
+        long operationTxSize = blockSizeKb * numOfBlocks * numOfSamples;
+        if (benchmarkType == BenchmarkType.READ_WRITE
+                || benchmarkType == BenchmarkType.READ) {
+            return 2L * operationTxSize;
+        }
+        return operationTxSize;
     }
     
     public static void updateMetrics(Sample s) {

--- a/src/jdiskmark/BenchmarkControlPanel.java
+++ b/src/jdiskmark/BenchmarkControlPanel.java
@@ -102,7 +102,7 @@ public class BenchmarkControlPanel extends JPanel {
                 if (selected != null) {
                     App.numOfBlocks = (Integer) selected;
                     //sampleSizeLabel.setText(String.valueOf(App.targetMarkSizeKb()));
-                    //totalTxProgBar.setString(String.valueOf(App.targetTxSizeKb()));
+                    Gui.progressBar.setString(String.valueOf(App.targetTxSizeKb()));
                     App.saveConfig();
                 }
             }
@@ -115,7 +115,7 @@ public class BenchmarkControlPanel extends JPanel {
                 if (selected != null) {
                     App.blockSizeKb = (Integer) selected;
                     //sampleSizeLabel.setText(String.valueOf(App.targetMarkSizeKb()));
-                    //totalTxProgBar.setString(String.valueOf(App.targetTxSizeKb()));
+                    Gui.progressBar.setString(String.valueOf(App.targetTxSizeKb()));
                     App.saveConfig();
                 }
             }
@@ -128,7 +128,7 @@ public class BenchmarkControlPanel extends JPanel {
                 if (selected != null) {
                     App.numOfSamples = (Integer) selected;
                     //sampleSizeLabel.setText(String.valueOf(App.targetMarkSizeKb()));
-                    //totalTxProgBar.setString(String.valueOf(App.targetTxSizeKb()));
+                    Gui.progressBar.setString(String.valueOf(App.targetTxSizeKb()));
                     App.saveConfig();
                 }
             }

--- a/src/jdiskmark/Exporter.java
+++ b/src/jdiskmark/Exporter.java
@@ -1,5 +1,6 @@
 package jdiskmark;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
@@ -12,6 +13,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JFileChooser;
@@ -32,6 +34,9 @@ public class Exporter {
             return extension;
         }
     }
+    
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = 
+            new TypeReference<Map<String, Object>>() {};
 
     private static final Logger logger = Logger.getLogger(Exporter.class.getName());
     
@@ -90,10 +95,10 @@ public class Exporter {
         mapper.registerModule(new JavaTimeModule());
 
         // 1. Flatten samples and inject the ioMode from the parent operation
-        // We convert the Sample object to a Map so we can dynamically add the "ioMode" column
+        // Convert Sample object to a Map so we can dynamically add the "ioMode" column
         var data = benchmark.getOperations().stream()
                 .flatMap(op -> op.getSamples().stream().map(s -> {
-                    java.util.Map<String, Object> row = mapper.convertValue(s, java.util.Map.class);
+                    java.util.Map<String, Object> row = mapper.convertValue(s, MAP_TYPE);
                     row.put("ioMode", op.getIoMode()); // Injects "READ" or "WRITE"
                     return row;
                 }))

--- a/src/jdiskmark/Gui.java
+++ b/src/jdiskmark/Gui.java
@@ -14,11 +14,16 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Shape;
 import java.awt.geom.Rectangle2D;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import javax.swing.JOptionPane;
 import javax.swing.JProgressBar;
+import javax.swing.SwingWorker.StateValue;
+import static javax.swing.SwingWorker.StateValue.DONE;
+import static javax.swing.SwingWorker.StateValue.STARTED;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 import static jdiskmark.Benchmark.IOMode.READ;
@@ -177,6 +182,37 @@ public final class Gui {
         configureLightLaf();
         FlatLaf.updateUI();
         updateChartPanelStyle();
+    }
+    
+    /**
+     * Handles progress and state updates from the SwingWorker 
+     * and updates the progress bar accordingly.
+     */
+    public static class WorkerProgressListener implements PropertyChangeListener {
+        @Override
+        public void propertyChange(PropertyChangeEvent event) {
+            long targetSize = App.targetTxSizeKb();
+            
+            switch (event.getPropertyName()) {
+                case "progress" -> {
+                    int value = (Integer) event.getNewValue();
+                    long kbProcessed = value * targetSize / 100;
+                    String progressText = String.format("%d / %d", kbProcessed, targetSize);
+                    progressBar.setValue(value);
+                    progressBar.setString(progressText);
+                }
+                case "state" -> {
+                    String targetTxSize = String.valueOf(App.targetTxSizeKb());
+                    switch ((StateValue)event.getNewValue()) {
+                        case STARTED -> Gui.progressBar.setString("0 / " + targetTxSize);
+                        case DONE -> { 
+                            progressBar.setString("Completed [" + App.targetTxSizeKb() + "]");
+                            progressBar.setValue(100);
+                        }
+                    } // end inner switch
+                }
+            }
+        }
     }
     
     public static void init() {
@@ -664,7 +700,6 @@ public final class Gui {
      * The original color scheme.
      */
     static void setClassicColorScheme() {
-        System.out.println("setting classic palette");
         palette = Palette.CLASSIC;
         
         // configure the bw series colors

--- a/src/jdiskmark/Gui.java
+++ b/src/jdiskmark/Gui.java
@@ -206,7 +206,7 @@ public final class Gui {
                     switch ((StateValue)event.getNewValue()) {
                         case STARTED -> Gui.progressBar.setString("0 / " + targetTxSize);
                         case DONE -> { 
-                            progressBar.setString("Completed [" + App.targetTxSizeKb() + "]");
+                            progressBar.setString(targetTxSize);
                             progressBar.setValue(100);
                         }
                     } // end inner switch
@@ -609,6 +609,11 @@ public final class Gui {
         }
     }
     
+    public static void resetProgressBar() {
+        progressBar.setString(String.valueOf(App.targetTxSizeKb()));
+        progressBar.setValue(0);
+    }
+    
     static public void loadBenchmark(Benchmark benchmark) {
         resetBenchmarkData();
         chart.getTitle().setText(benchmark.getDriveInfoDisplay());
@@ -655,6 +660,7 @@ public final class Gui {
                 }
             }
         }
+        resetProgressBar();
     }
     
     static public void loadOperation(BenchmarkOperation operation) {        
@@ -694,6 +700,7 @@ public final class Gui {
                 controlPanel.refreshWriteMetrics();
             }
         }
+        resetProgressBar();
     }
 
     /**


### PR DESCRIPTION
summary of changes:
1. set progress bar on tx size modification
2. set progress bar on benchmark load
3. set progress bar on worker thread complete
4. relocate property change listener from App to Gui
5. remove unsued eclipse property
6. more accurate benchmark tx size, accounts for both ops
