### PR TITLE
#135 seperate benchmark tx size from op sample size

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,9 @@ Source is available on our [github repo](https://github.com/JDiskMark/jdm-java/)
     - TODO: #117 user portal upload acknowledgement
     - TODO: #118 test interlock or OAuth upload
 
-### v0.7.0 proposed
+### v0.7.0
 - #44 gui benchmark export for json, yml, csv
+- #67 rename sample fields `bwt` > `bt`, `lat` > `lt`
 - #130 dark flatlaf
 - #131 default direct io
 - #132 fix read only benchmarks
@@ -218,7 +219,7 @@ Source is available on our [github repo](https://github.com/JDiskMark/jdm-java/)
     - cli options for: profile, direct io, alignment
     - new profiles: media playback, video export, photo library
 - #111 extract cfg model from benchmark
-- TODO: remove custom profile option
+- #42 replace `Custom Test` option w profileModified flag
 
 ### v0.6.3
 - #82 drive access notification

--- a/src/jdiskmark/App.java
+++ b/src/jdiskmark/App.java
@@ -452,7 +452,7 @@ public class App {
         config.blockSize = (long) blockSizeKb * KILOBYTE;
         config.numSamples = numOfSamples;
         config.numThreads = numOfThreads;
-        config.txSize = targetTxSizeKb();
+        config.txSize = targetOperationTxSizeKb();
         config.ioEngine = ioEngine;
         config.directIoEnabled = directEnable;
         config.writeSyncEnabled = writeSyncEnable;
@@ -637,17 +637,21 @@ public class App {
         }
     }
     
-    public static long targetMarkSizeKb() {
-        return blockSizeKb * numOfBlocks;
+    public static long targetSampleSizeKb() {
+        return (long)blockSizeKb * numOfBlocks;
+    }
+
+    public static long targetOperationTxSizeKb() {
+        return (long)blockSizeKb * numOfBlocks * numOfSamples;
     }
     
-    public static long targetTxSizeKb() {
-        long operationTxSize = (long)blockSizeKb * numOfBlocks * numOfSamples;
-        if (benchmarkType == BenchmarkType.READ_WRITE
-                || benchmarkType == BenchmarkType.READ) {
-            return 2L * operationTxSize;
+    public static long targetBenchmarkTxSizeKb() {
+        long operationTxSize = targetOperationTxSizeKb();
+        switch (benchmarkType) {
+            case WRITE -> { return operationTxSize; }
+            case READ, READ_WRITE -> { return 2L * operationTxSize; }
+            default -> throw new IllegalStateException("Unexpected value: " + benchmarkType);
         }
-        return operationTxSize;
     }
     
     public static void updateMetrics(Sample s) {

--- a/src/jdiskmark/BenchmarkControlPanel.java
+++ b/src/jdiskmark/BenchmarkControlPanel.java
@@ -102,7 +102,7 @@ public class BenchmarkControlPanel extends JPanel {
                 if (selected != null) {
                     App.numOfBlocks = (Integer) selected;
                     //sampleSizeLabel.setText(String.valueOf(App.targetMarkSizeKb()));
-                    Gui.progressBar.setString(String.valueOf(App.targetTxSizeKb()));
+                    Gui.progressBar.setString(String.valueOf(App.targetBenchmarkTxSizeKb()));
                     App.saveConfig();
                 }
             }
@@ -115,7 +115,7 @@ public class BenchmarkControlPanel extends JPanel {
                 if (selected != null) {
                     App.blockSizeKb = (Integer) selected;
                     //sampleSizeLabel.setText(String.valueOf(App.targetMarkSizeKb()));
-                    Gui.progressBar.setString(String.valueOf(App.targetTxSizeKb()));
+                    Gui.progressBar.setString(String.valueOf(App.targetBenchmarkTxSizeKb()));
                     App.saveConfig();
                 }
             }
@@ -128,7 +128,7 @@ public class BenchmarkControlPanel extends JPanel {
                 if (selected != null) {
                     App.numOfSamples = (Integer) selected;
                     //sampleSizeLabel.setText(String.valueOf(App.targetMarkSizeKb()));
-                    Gui.progressBar.setString(String.valueOf(App.targetTxSizeKb()));
+                    Gui.progressBar.setString(String.valueOf(App.targetBenchmarkTxSizeKb()));
                     App.saveConfig();
                 }
             }

--- a/src/jdiskmark/BenchmarkRunner.java
+++ b/src/jdiskmark/BenchmarkRunner.java
@@ -121,9 +121,16 @@ public class BenchmarkRunner {
             runReadPreparation(tRanges);
         }
         
-        if (!config.getDirectIoEnabled() && !listener.isCancelled() &&
-                config.hasReadOperation() && config.hasWriteOperation()) {
-            throttledProgressUpdate(true);
+        throttledProgressUpdate(true);
+        
+        // cache reset if
+        // 1. not cancelled
+        // 2. read operation
+        // 3. !directIo || (directIo & macOs)
+        boolean isMacOs = App.os.toLowerCase().contains("mac");
+        if (!listener.isCancelled() && config.hasReadOperation() &&
+                (!config.getDirectIoEnabled() || 
+                (config.getDirectIoEnabled() && isMacOs))) {    
             listener.attemptCacheDrop();
         }
         

--- a/src/jdiskmark/Cli.java
+++ b/src/jdiskmark/Cli.java
@@ -46,8 +46,7 @@ public class Cli {
 
                         Removable drives can be disconnected and reconnected.
 
-                        For system drives perform a WRITE benchmark, restart 
-                        the OS and then perform a READ benchmark.
+                        runn command `sudo purge`
 
                         Press OK to continue when disk cache has been cleared.""";
                 System.out.println(message);
@@ -81,9 +80,6 @@ public class Cli {
                         For valid READ benchmarks please clear the disk cache by
                         using EmptyStandbyList.exe or RAMMap.exe utilities.
 
-                        For system drives perform a WRITE benchmark, restart 
-                        the OS and then perform a READ benchmark.
-
                         Press OK to continue when disk cache has been cleared.
                         """;
                 System.out.println(message);
@@ -100,9 +96,6 @@ public class Cli {
                         For valid READ benchmarks please clear the disk cache by
                         using EmptyStandbyList.exe or RAMMap.exe utilities.
 
-                        For system drives perform a WRITE benchmark, restart 
-                        the OS and then perform a READ benchmark.
-
                         Press OK to continue when disk cache has been cleared.""";
                 System.out.println(message);
                 try (Scanner scanner = new Scanner(System.in)) {
@@ -118,9 +111,6 @@ public class Cli {
                     For valid READ benchmarks please clear the disk cache now.
 
                     Removable drives can be disconnected and reconnected.
-
-                    For system drives perform a WRITE benchmark, restart 
-                    the OS and then perform a READ benchmarks benchmark.
 
                     Press OK to continue when disk cache has been cleared.""";
             System.out.println(message);

--- a/src/jdiskmark/Gui.java
+++ b/src/jdiskmark/Gui.java
@@ -191,7 +191,7 @@ public final class Gui {
     public static class WorkerProgressListener implements PropertyChangeListener {
         @Override
         public void propertyChange(PropertyChangeEvent event) {
-            long targetSize = App.targetTxSizeKb();
+            long targetSize = App.targetBenchmarkTxSizeKb();
             
             switch (event.getPropertyName()) {
                 case "progress" -> {
@@ -202,7 +202,7 @@ public final class Gui {
                     progressBar.setString(progressText);
                 }
                 case "state" -> {
-                    String targetTxSize = String.valueOf(App.targetTxSizeKb());
+                    String targetTxSize = String.valueOf(App.targetBenchmarkTxSizeKb());
                     switch ((StateValue)event.getNewValue()) {
                         case STARTED -> Gui.progressBar.setString("0 / " + targetTxSize);
                         case DONE -> { 
@@ -213,6 +213,11 @@ public final class Gui {
                 }
             }
         }
+    }
+    
+    public static void resetProgressBar() {
+        progressBar.setString(String.valueOf(App.targetBenchmarkTxSizeKb()));
+        progressBar.setValue(0);
     }
     
     public static void init() {
@@ -607,11 +612,6 @@ public final class Gui {
                     message, "Clear Disk Cache Now",
                     JOptionPane.PLAIN_MESSAGE);
         }
-    }
-    
-    public static void resetProgressBar() {
-        progressBar.setString(String.valueOf(App.targetTxSizeKb()));
-        progressBar.setValue(0);
     }
     
     static public void loadBenchmark(Benchmark benchmark) {

--- a/src/jdiskmark/Gui.java
+++ b/src/jdiskmark/Gui.java
@@ -542,8 +542,7 @@ public final class Gui {
 
                         Removable drives can be disconnected and reconnected.
 
-                        For system drives perform a WRITE benchmark, restart 
-                        the OS and then perform a READ benchmark.
+                        sudo purge
 
                         Press OK to continue when disk cache has been cleared.""";
                 JOptionPane.showMessageDialog(mainFrame, 
@@ -573,9 +572,6 @@ public final class Gui {
                         For valid READ benchmarks please clear the disk cache by
                         using EmptyStandbyList.exe or RAMMap.exe utilities.
 
-                        For system drives perform a WRITE benchmark, restart 
-                        the OS and then perform a READ benchmark.
-
                         Press OK to continue when disk cache has been cleared.
                         """;
                 JOptionPane.showMessageDialog(mainFrame, 
@@ -589,9 +585,6 @@ public final class Gui {
                         For valid READ benchmarks please clear the disk cache by
                         using EmptyStandbyList.exe or RAMMap.exe utilities.
 
-                        For system drives perform a WRITE benchmark, restart 
-                        the OS and then perform a READ benchmark.
-
                         Press OK to continue when disk cache has been cleared.""";
                 JOptionPane.showMessageDialog(mainFrame, 
                         message, "Clear Disk Cache Now",
@@ -603,9 +596,6 @@ public final class Gui {
                     For valid READ benchmarks please clear the disk cache now.
 
                     Removable drives can be disconnected and reconnected.
-
-                    For system drives perform a WRITE benchmark, restart 
-                    the OS and then perform a READ benchmarks benchmark.
 
                     Press OK to continue when disk cache has been cleared.""";
             JOptionPane.showMessageDialog(mainFrame,

--- a/src/jdiskmark/MainFrame.java
+++ b/src/jdiskmark/MainFrame.java
@@ -1096,7 +1096,7 @@ public final class MainFrame extends javax.swing.JFrame {
         if (Gui.controlPanel != null) {
             Gui.controlPanel.applySettings();
         }
-        totalTxProgBar.setString(String.valueOf(App.targetTxSizeKb()));
+        totalTxProgBar.setString(String.valueOf(App.targetBenchmarkTxSizeKb()));
     }
     
     public javax.swing.JProgressBar getProgressBar() {


### PR DESCRIPTION
summary of changes

1. restore drop disk cache dialog for direct io for mac os
2. separate operation tx size from benchmark tx size

<img width="2010" height="1502" alt="image" src="https://github.com/user-attachments/assets/f175ceac-3ded-40a5-a668-24665f82b9bd" />
