### PR TITLE
#117 initial sharing acknowledgement

### DIFF
--- a/jdm-core/src/main/java/jdiskmark/App.java
+++ b/jdm-core/src/main/java/jdiskmark/App.java
@@ -592,7 +592,7 @@ public class App {
             msg("Portal upload enabled — thank you for sharing!");
         } else {
             sharePortal = false;
-            msg("Portal upload declined. You can enable it later via Help \u203a Portal Upload.");
+            msg("Portal upload declined. You can enable it later via the Sharing tab.");
         }
         saveConfig(); // persist consent flag and choice immediately
         // sync the Sharing tab to reflect the resolved state

--- a/jdm-core/src/main/java/jdiskmark/App.java
+++ b/jdm-core/src/main/java/jdiskmark/App.java
@@ -566,9 +566,9 @@ public class App {
 
     /**
      * Shows the one-time first-run consent dialog for anonymous portal upload
-     * (issue #117). Fires only when the production endpoint is configured and
-     * {@link #portalConsentAsked} is {@code false}. After the user responds the
-     * flag is set to {@code true} and persisted so the dialog never appears again.
+     * (issue #117). Fires when {@link #portalConsentAsked} is {@code false}.
+     * After the user responds the flag is set to {@code true} and persisted so
+     * the dialog never appears again.
      */
     public static void promptFirstRunPortalConsent() {
         String message = "<html><body style='width:380px'>"

--- a/jdm-core/src/main/java/jdiskmark/App.java
+++ b/jdm-core/src/main/java/jdiskmark/App.java
@@ -113,24 +113,24 @@ public class App {
      */
     public enum AppIcon {
         /** Blue/orange circle — the beta brand. Single resolution. */
-        BETA(new String[]{"/icons/icon-jdm-beta.png"}),
+        BETA(new String[] { "/icons/icon-jdm-beta.png" }),
         /** Custom JDiskMark turtle logo — the default project brand. */
-        TURTLE(new String[]{
-            "/icons/jdm-turtle-logo-16x16.png",
-            "/icons/jdm-turtle-logo-20x20.png",
-            "/icons/jdm-turtle-logo-24x24.png",
-            "/icons/jdm-turtle-logo-32x32.png",
-            "/icons/jdm-turtle-logo-40x40.png",
-            "/icons/jdm-turtle-logo-48x48.png",
-            "/icons/jdm-turtle-logo-64x64.png",
-            "/icons/jdm-turtle-logo-96x96.png",
-            "/icons/jdm-turtle-logo-128x128.png",
-            "/icons/jdm-turtle-logo-256x256.png",
-            "/icons/jdm-turtle-logo-512x512.png",
-            "/icons/jdm-turtle-logo-1024x1024.png"
+        TURTLE(new String[] {
+                "/icons/jdm-turtle-logo-16x16.png",
+                "/icons/jdm-turtle-logo-20x20.png",
+                "/icons/jdm-turtle-logo-24x24.png",
+                "/icons/jdm-turtle-logo-32x32.png",
+                "/icons/jdm-turtle-logo-40x40.png",
+                "/icons/jdm-turtle-logo-48x48.png",
+                "/icons/jdm-turtle-logo-64x64.png",
+                "/icons/jdm-turtle-logo-96x96.png",
+                "/icons/jdm-turtle-logo-128x128.png",
+                "/icons/jdm-turtle-logo-256x256.png",
+                "/icons/jdm-turtle-logo-512x512.png",
+                "/icons/jdm-turtle-logo-1024x1024.png"
         }),
         /** Duke, the BSD-licensed Java mascot from the OpenJDK project. */
-        DUKE(new String[]{"/icons/icon-duke.png"});
+        DUKE(new String[] { "/icons/icon-duke.png" });
 
         /** All resource paths for this icon variant, from smallest to largest. */
         public final String[] resourcePaths;
@@ -243,23 +243,44 @@ public class App {
     public static String arch;
     public static String processorName;
     public static String jdk;
-    public static String username;
+    // PII: OS username collection removed (#117 — use anonymous or a non-PII system id instead).
+    // public static String username;
+
+    /**
+     * Stable, non-PII system identifier (32-char SHA-256 hex derived from the
+     * OS machine GUID / machine-id). Persisted in {@code jdm.properties} so
+     * it survives app restarts. See {@link UtilOs#getMachineSystemId}.
+     */
+    public static String systemId;
 
     // --- OS convenience helpers ---
     // Delegate to UtilOs primitives. Safe to call before init() (e.g. early in
     // main() or in CLI mode where App.os is never populated).
 
     /** Returns {@code true} when running on macOS. */
-    public static boolean isMacOs() { return UtilOs.isMacOs(osName()); }
+    public static boolean isMacOs() {
+        return UtilOs.isMacOs(osName());
+    }
+
     /** Returns {@code true} when running on Windows. */
-    public static boolean isWindows() { return UtilOs.isWindows(osName()); }
+    public static boolean isWindows() {
+        return UtilOs.isWindows(osName());
+    }
+
     /** Returns {@code true} when running on Linux. */
-    public static boolean isLinux() { return UtilOs.isLinux(osName()); }
-    /** Resolves the OS name, falling back to the system property when {@link #os} is not yet set.
-     *  Safe to call before {@link #init()} and in CLI mode. */
+    public static boolean isLinux() {
+        return UtilOs.isLinux(osName());
+    }
+
+    /**
+     * Resolves the OS name, falling back to the system property when {@link #os} is
+     * not yet set.
+     * Safe to call before {@link #init()} and in CLI mode.
+     */
     public static String osName() {
         return (os != null) ? os : System.getProperty("os.name", "");
     }
+
     // benchmark options
     public static Properties p;
     public static File locationDir = null;
@@ -269,9 +290,11 @@ public class App {
     public static boolean autoSave = false;
     public static boolean sharePortal = false;
     // True if sharePortal was enabled in the last session; used to offer a
-    // one-click
-    // re-enable prompt at startup rather than silently resuming network activity.
+    // one-click re-enable prompt at startup rather than silently resuming network activity.
     public static boolean sharePortalPreviouslyEnabled = false;
+    // True once the user has answered the first-run portal-consent prompt.
+    // Persisted so the prompt is shown exactly once (issue #117).
+    public static boolean portalConsentAsked = false;
     public static boolean verbose = false; // affects cli output
     public static boolean multiFile = true;
     public static boolean autoRemoveData = true;
@@ -393,13 +416,11 @@ public class App {
 
         GcDetector.printActive();
 
-        username = System.getProperty("user.name");
-
         os = System.getProperty("os.name");
         arch = System.getProperty("os.arch");
         processorName = Util.getProcessorName();
         jdk = Util.getJvmInfo();
-
+        
         checkPermission();
         if (!APP_CACHE_DIR.exists()) {
             APP_CACHE_DIR.mkdirs();
@@ -408,6 +429,14 @@ public class App {
         if (mode == Mode.GUI) {
             loadConfig();
         }
+
+        // Derive the stable, non-PII machine identifier now that loadConfig() has
+        // populated the persisted fallback value (if any). Resolved after loadConfig
+        // so we never clobber portalConsentAsked or other flags with a premature
+        // saveConfig() call.
+        String fallbackSystemId = (systemId != null && !systemId.isBlank()) ? systemId : "";
+        systemId = UtilOs.getMachineSystemId(os, fallbackSystemId);
+        // systemId persisted by the shutdown-hook saveConfig() and other normal save paths.
 
         // initialize data dir if necessary
         if (locationDir == null) {
@@ -437,11 +466,23 @@ public class App {
                     App.saveConfig();
                 }
             });
-            // If portal upload was active last session, offer a one-click re-enable.
-            // This avoids silent outbound network activity while keeping dev workflow
-            // smooth.
-            if (sharePortalPreviouslyEnabled) {
-                javax.swing.SwingUtilities.invokeLater(App::promptResumePortalUpload);
+            // #117 First-run consent: ask once if the user has never been asked.
+            // Fires for both test and production endpoints so the dialog can be
+            // exercised from the IDE without any config changes.
+            // This runs before the re-enable check so a brand-new install shows
+            // the consent dialog rather than nothing.
+            if (!portalConsentAsked) {
+                javax.swing.SwingUtilities.invokeLater(App::promptFirstRunPortalConsent);
+            } else if (sharePortalPreviouslyEnabled) {
+                // Consent was already given and upload was active last session —
+                // silently restore it. No need to ask again once consent is on record.
+                sharePortal = true;
+                javax.swing.SwingUtilities.invokeLater(() -> {
+                    msg("Portal upload active — disable via the Sharing tab.");
+                    if (Gui.mainFrame != null) {
+                        Gui.mainFrame.loadPropertiesConfig();
+                    }
+                });
             }
         }
     }
@@ -450,13 +491,15 @@ public class App {
      * Attempts to acquire an OS-level advisory lock on a file in the per-version
      * cache directory. Called once at startup in GUI mode, before {@link #init()}.
      *
-     * <p>The lock is held by a {@link java.nio.channels.FileLock} whose lifecycle
+     * <p>
+     * The lock is held by a {@link java.nio.channels.FileLock} whose lifecycle
      * is tied to the JVM process: the OS kernel releases it automatically when the
      * process exits by <em>any</em> means (normal exit, uncaught exception,
      * {@code SIGKILL}, OOM crash). Stale lock files left behind after a crash are
      * therefore impossible — the next launch will always succeed.
      *
-     * <p>If another instance already holds the lock a user-friendly dialog is shown
+     * <p>
+     * If another instance already holds the lock a user-friendly dialog is shown
      * and the method returns {@code false}, allowing {@code main()} to exit cleanly
      * without opening any window or touching the Derby database.
      *
@@ -498,7 +541,7 @@ public class App {
                 javax.swing.JOptionPane.showMessageDialog(
                         null,
                         "JDiskMark is already running.\n"
-                        + "Only one instance can be open at a time.",
+                                + "Only one instance can be open at a time.",
                         "JDiskMark — Already Running",
                         javax.swing.JOptionPane.WARNING_MESSAGE);
                 System.exit(0);
@@ -518,6 +561,43 @@ public class App {
         }
         if (isRoot || isAdmin) {
             System.out.println("Running w elevated priviledges");
+        }
+    }
+
+    /**
+     * Shows the one-time first-run consent dialog for anonymous portal upload
+     * (issue #117). Fires only when the production endpoint is configured and
+     * {@link #portalConsentAsked} is {@code false}. After the user responds the
+     * flag is set to {@code true} and persisted so the dialog never appears again.
+     */
+    public static void promptFirstRunPortalConsent() {
+        String message = "<html><body style='width:380px'>"
+                + "<b>Help improve JDiskMark by sharing your results!</b><br><br>"
+                + "Would you like to share your benchmark results with "
+                + "the JDiskMark community portal?<br><br>"
+                + "<ul>"
+                + "<li>Only benchmark metrics (speeds, block sizes, OS) are submitted.</li>"
+                + "<li>You can change this at any time via the <i>Sharing</i> tab.</li>"
+                + "</ul>"
+                + "</body></html>";
+        int choice = javax.swing.JOptionPane.showConfirmDialog(
+                Gui.mainFrame,
+                new javax.swing.JLabel(message),
+                "Share Benchmark Results?",
+                javax.swing.JOptionPane.YES_NO_OPTION,
+                javax.swing.JOptionPane.QUESTION_MESSAGE);
+        portalConsentAsked = true; // mark as answered regardless of choice
+        if (choice == javax.swing.JOptionPane.YES_OPTION) {
+            sharePortal = true;
+            msg("Portal upload enabled — thank you for sharing!");
+        } else {
+            sharePortal = false;
+            msg("Portal upload declined. You can enable it later via Help \u203a Portal Upload.");
+        }
+        saveConfig(); // persist consent flag and choice immediately
+        // sync the Sharing tab to reflect the resolved state
+        if (Gui.mainFrame != null) {
+            Gui.mainFrame.loadPropertiesConfig();
         }
     }
 
@@ -601,6 +681,13 @@ public class App {
         value = p.getProperty("sharePortal", "false");
         sharePortalPreviouslyEnabled = Boolean.parseBoolean(value);
         sharePortal = false; // always start disabled; prompt offered after window visible
+
+        // #117 one-time first-run consent flag
+        value = p.getProperty("portalConsentAsked", "false");
+        portalConsentAsked = Boolean.parseBoolean(value);
+
+        // Non-PII system identifier (blank on very first run; resolved in init())
+        systemId = p.getProperty("systemId", "");
 
         Portal.uploadResourceLocator = p.getProperty("uploadResourceLocator", Portal.uploadResourceLocator);
         Portal.uploadProtocol = p.getProperty("uploadProtocol", Portal.uploadProtocol);
@@ -709,8 +796,16 @@ public class App {
 
         // configure properties
         p.setProperty("sharePortal", String.valueOf(sharePortal));
-        p.setProperty("uploadResourceLocator", Portal.uploadResourceLocator);
-        p.setProperty("uploadProtocol", Portal.uploadProtocol);
+        p.setProperty("portalConsentAsked", String.valueOf(portalConsentAsked)); // #117
+        if (systemId != null && !systemId.isBlank()) {
+            p.setProperty("systemId", systemId);
+        }
+        if (Portal.uploadResourceLocator != null) {
+            p.setProperty("uploadResourceLocator", Portal.uploadResourceLocator);
+        }
+        if (Portal.uploadProtocol != null) {
+            p.setProperty("uploadProtocol", Portal.uploadProtocol);
+        }
         p.setProperty("activeProfile", activeProfile.name());
         p.setProperty("profileModified", String.valueOf(profileModified));
         p.setProperty("benchmarkType", benchmarkType.name());

--- a/jdm-core/src/main/java/jdiskmark/App.java
+++ b/jdm-core/src/main/java/jdiskmark/App.java
@@ -472,7 +472,7 @@ public class App {
             // This runs before the re-enable check so a brand-new install shows
             // the consent dialog rather than nothing.
             if (!portalConsentAsked) {
-                javax.swing.SwingUtilities.invokeLater(App::promptFirstRunPortalConsent);
+                javax.swing.SwingUtilities.invokeLater(Gui::promptFirstRunPortalConsent);
             } else if (sharePortalPreviouslyEnabled) {
                 // Consent was already given and upload was active last session —
                 // silently restore it. No need to ask again once consent is on record.
@@ -564,72 +564,6 @@ public class App {
         }
     }
 
-    /**
-     * Shows the one-time first-run consent dialog for anonymous portal upload
-     * (issue #117). Fires when {@link #portalConsentAsked} is {@code false}.
-     * After the user responds the flag is set to {@code true} and persisted so
-     * the dialog never appears again.
-     */
-    public static void promptFirstRunPortalConsent() {
-        String message = "<html><body style='width:380px'>"
-                + "<b>Help improve JDiskMark by sharing your results!</b><br><br>"
-                + "Would you like to share your benchmark results with "
-                + "the JDiskMark community portal?<br><br>"
-                + "<ul>"
-                + "<li>Only benchmark metrics (speeds, block sizes, OS) are submitted.</li>"
-                + "<li>You can change this at any time via the <i>Sharing</i> tab.</li>"
-                + "</ul>"
-                + "</body></html>";
-        int choice = javax.swing.JOptionPane.showConfirmDialog(
-                Gui.mainFrame,
-                new javax.swing.JLabel(message),
-                "Share Benchmark Results?",
-                javax.swing.JOptionPane.YES_NO_OPTION,
-                javax.swing.JOptionPane.QUESTION_MESSAGE);
-        portalConsentAsked = true; // mark as answered regardless of choice
-        if (choice == javax.swing.JOptionPane.YES_OPTION) {
-            sharePortal = true;
-            msg("Portal upload enabled — thank you for sharing!");
-        } else {
-            sharePortal = false;
-            msg("Portal upload declined. You can enable it later via the Sharing tab.");
-        }
-        saveConfig(); // persist consent flag and choice immediately
-        // sync the Sharing tab to reflect the resolved state
-        if (Gui.mainFrame != null) {
-            Gui.mainFrame.loadPropertiesConfig();
-        }
-    }
-
-    /**
-     * Offers a one-click prompt to re-enable portal upload when it was active
-     * in the previous session. Called after the main window is visible so the
-     * dialog has a proper parent. This avoids silent outbound network activity
-     * while keeping the dev workflow convenient (no password re-entry required).
-     */
-    public static void promptResumePortalUpload() {
-        int choice = javax.swing.JOptionPane.showConfirmDialog(
-                Gui.mainFrame,
-                "Portal upload was enabled in your last session.\nResume uploading benchmarks to "
-                        + Portal.getUploadUrl() + "?",
-                "Resume Portal Upload?",
-                javax.swing.JOptionPane.YES_NO_OPTION,
-                javax.swing.JOptionPane.QUESTION_MESSAGE);
-        if (choice == javax.swing.JOptionPane.YES_OPTION) {
-            sharePortal = true;
-            msg("Portal upload resumed.");
-        } else {
-            sharePortal = false;
-            sharePortalPreviouslyEnabled = false; // clear so we don't prompt again next launch
-            msg("Portal upload not resumed.");
-            saveConfig(); // persist the cleared state
-        }
-        // sync the menu checkbox to reflect the resolved state
-        if (Gui.mainFrame != null) {
-            Gui.mainFrame.loadPropertiesConfig();
-        }
-    }
-
     public static void loadProfile(BenchmarkProfile profile) {
         try {
             activeProfile = profile;
@@ -675,9 +609,7 @@ public class App {
         // configure settings from properties
         String value;
 
-        // Never silently re-enable portal upload on startup — network activity must
-        // always be explicitly user-confirmed each session. We remember the previous
-        // state only to offer a convenient one-click re-enable prompt.
+        // Remember previous state only to offer convenient one-click re-enable prompt.
         value = p.getProperty("sharePortal", "false");
         sharePortalPreviouslyEnabled = Boolean.parseBoolean(value);
         sharePortal = false; // always start disabled; prompt offered after window visible

--- a/jdm-core/src/main/java/jdiskmark/Benchmark.java
+++ b/jdm-core/src/main/java/jdiskmark/Benchmark.java
@@ -126,8 +126,7 @@ public class Benchmark implements Serializable {
     @JsonSerialize(using = UuidToMongoIdSerializer.class)
     private UUID id;
     
-    // PII: username field disabled (#117). Defaults to "anonymous" for portal upload.
-    // Restore (or replace with a non-PII device/machine id) when needed.
+    // PII: #117 set only after a user elects to login to access their profile
     // @Column
     String username = "anonymous"; // "user" is reserved in Derby
     // public String getUsername() { return username; }

--- a/jdm-core/src/main/java/jdiskmark/Benchmark.java
+++ b/jdm-core/src/main/java/jdiskmark/Benchmark.java
@@ -126,10 +126,22 @@ public class Benchmark implements Serializable {
     @JsonSerialize(using = UuidToMongoIdSerializer.class)
     private UUID id;
     
-    // user account
-    @Column
+    // PII: username field disabled (#117). Defaults to "anonymous" for portal upload.
+    // Restore (or replace with a non-PII device/machine id) when needed.
+    // @Column
     String username = "anonymous"; // "user" is reserved in Derby
-    public String getUsername() { return username; }
+    // public String getUsername() { return username; }
+    public String getUsername() { return "anonymous"; }
+
+    /**
+     * Non-PII stable system identifier derived from the OS machine GUID / machine-id.
+     * 32-char lowercase SHA-256 hex.  Set from {@link App#systemId} at benchmark
+     * creation time and included in every portal upload payload.
+     * See {@link UtilOs#getMachineSystemId} for the derivation strategy.
+     */
+    @Column
+    String systemId = "";
+    public String getSystemId() { return systemId; }
     
     // system info
     @Embedded

--- a/jdm-core/src/main/java/jdiskmark/BenchmarkRunner.java
+++ b/jdm-core/src/main/java/jdiskmark/BenchmarkRunner.java
@@ -316,8 +316,8 @@ public class BenchmarkRunner {
     }
     
     private void mapEnvironment(Benchmark b, String model, String partId, DiskUsageInfo u) {
-        b.username = App.username;
-        
+        b.systemId = (App.systemId != null) ? App.systemId : "";
+
         b.systemInfo.processorName = App.processorName;
         b.systemInfo.os = App.os;
         b.systemInfo.arch = App.arch;

--- a/jdm-core/src/main/java/jdiskmark/Gui.java
+++ b/jdm-core/src/main/java/jdiskmark/Gui.java
@@ -286,11 +286,31 @@ public final class Gui {
      */
     public static void showAboutDialog() {
         javax.swing.ImageIcon icon = App.activeIcon.loadSize(128);
-        String message = App.APP_NAME + " " + App.VERSION + "\n" +
-                "JVM: " + App.jdk + "\n" +
-                "OS:  " + App.os;
+
+        // Build an HTML panel so the website URL is a clickable hyperlink.
+        String url = "https://www.jdiskmark.net";
+        String html = "<html><body style='font-family:sans-serif;font-size:11px'>"
+                + "<b>" + App.APP_NAME + " " + App.VERSION + "</b><br>"
+                + "JVM: " + App.jdk + "<br>"
+                + "OS:&nbsp; " + App.os + "<br><br>"
+                + "<a href='" + url + "'>" + url + "</a>"
+                + "</body></html>";
+
+        javax.swing.JEditorPane msgPane = new javax.swing.JEditorPane("text/html", html);
+        msgPane.setEditable(false);
+        msgPane.setOpaque(false);
+        msgPane.addHyperlinkListener(e -> {
+            if (e.getEventType() == javax.swing.event.HyperlinkEvent.EventType.ACTIVATED) {
+                try {
+                    java.awt.Desktop.getDesktop().browse(new java.net.URI(url));
+                } catch (Exception ex) {
+                    App.msg("Could not open browser: " + ex.getMessage());
+                }
+            }
+        });
+
         javax.swing.JOptionPane.showMessageDialog(
-                mainFrame, message, "About " + App.APP_NAME,
+                mainFrame, msgPane, "About " + App.APP_NAME,
                 javax.swing.JOptionPane.PLAIN_MESSAGE, icon);
     }
     

--- a/jdm-core/src/main/java/jdiskmark/Gui.java
+++ b/jdm-core/src/main/java/jdiskmark/Gui.java
@@ -323,11 +323,11 @@ public final class Gui {
     public static void promptFirstRunPortalConsent() {
         String message = "<html><body style='width:380px'>"
                 + "<b>Help the community make smarter hardware decisions!</b><br><br>"
-                + "Your benchmark results, combined with others', help users compare real-world storage "
+                + "Your benchmark data, combined with others', help users compare real-world storage "
                 + "performance and identify reliability trends across drives and platforms.<br><br>"
                 + "Would you like to share your results with the jdiskmark.net community portal?<br><br>"
                 + "<ul>"
-                + "<li>Benchmark results (speeds, IOPS, latency) and hardware context (CPU, drive, OS) used to validate results.</li>"
+                + "<li>Performance metrics (speeds, IOPS, latency) and hardware context (CPU, drive, OS).</li>"
                 + "<li>A non-reversible system identifier — no name or account required.</li>"
                 + "<li>You can change this at any time via the <i>Sharing</i> tab.</li>"
                 + "</ul>"

--- a/jdm-core/src/main/java/jdiskmark/Gui.java
+++ b/jdm-core/src/main/java/jdiskmark/Gui.java
@@ -313,7 +313,72 @@ public final class Gui {
                 mainFrame, msgPane, "About " + App.APP_NAME,
                 javax.swing.JOptionPane.PLAIN_MESSAGE, icon);
     }
-    
+
+    /**
+     * #117 Shows the one-time first-run consent dialog for portal sharing.
+     * Fires when {@link App#portalConsentAsked} is {@code false}. After the user
+     * responds the flag is set to {@code true} and persisted so the dialog
+     * never appears again.
+     */
+    public static void promptFirstRunPortalConsent() {
+        String message = "<html><body style='width:380px'>"
+                + "<b>Help the community make smarter hardware decisions!</b><br><br>"
+                + "Your benchmark results, combined with others', help users compare real-world storage "
+                + "performance and identify reliability trends across drives and platforms.<br><br>"
+                + "Would you like to share your results with the jdiskmark.net community portal?<br><br>"
+                + "<ul>"
+                + "<li>Benchmark results (speeds, IOPS, latency) and hardware context (CPU, drive, OS) used to validate results.</li>"
+                + "<li>A non-reversible system identifier — no name or account required.</li>"
+                + "<li>You can change this at any time via the <i>Sharing</i> tab.</li>"
+                + "</ul>"
+                + "</body></html>";
+        int choice = javax.swing.JOptionPane.showConfirmDialog(
+                mainFrame,
+                new javax.swing.JLabel(message),
+                "Share Benchmark Results?",
+                javax.swing.JOptionPane.YES_NO_OPTION,
+                javax.swing.JOptionPane.QUESTION_MESSAGE);
+        App.portalConsentAsked = true; // mark as answered regardless of choice
+        if (choice == javax.swing.JOptionPane.YES_OPTION) {
+            App.sharePortal = true;
+            App.msg("Portal upload enabled — thank you for sharing!");
+        } else {
+            App.sharePortal = false;
+            App.msg("Portal upload declined. You can enable it later via the Sharing tab.");
+        }
+        App.saveConfig(); // persist consent flag and choice immediately
+        if (mainFrame != null) {
+            mainFrame.loadPropertiesConfig();
+        }
+    }
+
+    /**
+     * Offers a one-click prompt to re-enable portal upload when it was active
+     * in the previous session. Called after the main window is visible so the
+     * dialog has a proper parent.
+     */
+    public static void promptResumePortalUpload() {
+        int choice = javax.swing.JOptionPane.showConfirmDialog(
+                mainFrame,
+                "Portal upload was enabled in your last session.\nResume uploading benchmarks to "
+                        + Portal.getUploadUrl() + "?",
+                "Resume Portal Upload?",
+                javax.swing.JOptionPane.YES_NO_OPTION,
+                javax.swing.JOptionPane.QUESTION_MESSAGE);
+        if (choice == javax.swing.JOptionPane.YES_OPTION) {
+            App.sharePortal = true;
+            App.msg("Portal upload resumed.");
+        } else {
+            App.sharePortal = false;
+            App.sharePortalPreviouslyEnabled = false;
+            App.msg("Portal upload not resumed.");
+            App.saveConfig();
+        }
+        if (mainFrame != null) {
+            mainFrame.loadPropertiesConfig();
+        }
+    }
+
     public static void updateChartPanelStyle() {
         // correct the parenthesis from being below vertical centering
         chart.getTitle().setFont(new Font("Verdana", Font.BOLD, 17));

--- a/jdm-core/src/main/java/jdiskmark/MainFrame.java
+++ b/jdm-core/src/main/java/jdiskmark/MainFrame.java
@@ -21,6 +21,12 @@ import net.miginfocom.swing.MigLayout;
 public final class MainFrame extends javax.swing.JFrame {
 
     public static final DecimalFormat DF = new DecimalFormat("###.##");
+
+    /**
+     * Sharing tab panel — built programmatically, added to tabbedPane in the
+     * constructor.
+     */
+    public SharingPanel sharingPanel;
     
     /**
      * Creates new form MainFrame
@@ -45,8 +51,8 @@ public final class MainFrame extends javax.swing.JFrame {
         totalTxProgBar.setString("");
         
         StringBuilder titleSb = new StringBuilder();
-        titleSb.append(getTitle()).append(" ").append(App.VERSION);    
-
+        titleSb.append(getTitle()).append(" ").append(App.VERSION);
+        
         refreshConfig();
         bcPanel.configChangeDetection();
         
@@ -69,12 +75,21 @@ public final class MainFrame extends javax.swing.JFrame {
         // auto scroll the text area.
         DefaultCaret caret = (DefaultCaret)msgTextArea.getCaret();
         caret.setUpdatePolicy(DefaultCaret.ALWAYS_UPDATE);
+        
+        // #117 Sharing tab — added programmatically so the NetBeans form is untouched.
+        sharingPanel = new SharingPanel();
+        tabbedPane.addTab("Sharing", sharingPanel);
+        
+        // Hide the now-redundant Help-menu portal items; all controls live in the tab.
+        portalUploadMenuItem.setVisible(false);
+        portalEndpointMenu.setVisible(false);
+        portalProtocolMenu.setVisible(false);
     }
 
     public JPanel getMountPanel() {
         return cResultMountPanel;
     }
-    
+
     /**
      * This method is called when the gui needs to be updated after a new config
      * has been loaded.
@@ -85,24 +100,9 @@ public final class MainFrame extends javax.swing.JFrame {
             setLocation(App.locationDir.getAbsolutePath());
         }
         
-        // test portal settings
-        portalUploadMenuItem.setSelected(App.sharePortal);
-        portalEndpointMenu.setEnabled(App.sharePortal);
-        if (Portal.uploadResourceLocator.equalsIgnoreCase(Portal.LOCAL_UPLOAD_LOCATOR)) {
-            localEndpointRbMenuItem.setSelected(true);
-        }
-        if (Portal.uploadResourceLocator.equalsIgnoreCase(Portal.TEST_UPLOAD_LOCATOR)) {
-            testEndpointRbMenuItem.setSelected(true);
-        }
-        if (Portal.uploadResourceLocator.equalsIgnoreCase(Portal.PRODUCTION_UPLOAD_LOCATOR)) {
-            prodEndpointRbMenuItem.setSelected(true);
-        }
-        portalProtocolMenu.setEnabled(App.sharePortal);
-        if (Portal.uploadProtocol.equalsIgnoreCase(Portal.HTTP)) {
-            httpProtoRbMenuItem.setSelected(true);
-        }
-        if (Portal.uploadProtocol.equalsIgnoreCase(Portal.HTTPS)) {
-            httpsProtoRbMenuItem.setSelected(true);
+        // Sharing tab reflects the current portal state.
+        if (sharingPanel != null) {
+            sharingPanel.refresh();
         }
         
         multiFileCheckBoxMenuItem.setSelected(App.multiFile);
@@ -946,15 +946,6 @@ public final class MainFrame extends javax.swing.JFrame {
     }//GEN-LAST:event_resetBenchmarkItemActionPerformed
 
     private void portalUploadMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_portalUploadMenuItemActionPerformed
-        if (portalUploadMenuItem.getState() == true) {
-            PortalEnableDialog dialog = new PortalEnableDialog(this);
-            dialog.setVisible(true); // Execution pauses here because it's modal
-            if (!dialog.isAuthorized()) {
-                App.msg("test passcode required to upload benchmarks");
-                portalUploadMenuItem.setSelected(false);
-                return;
-            }
-        }
         App.sharePortal = portalUploadMenuItem.getState();
         App.saveConfig();
         if (App.sharePortal) {
@@ -1167,14 +1158,14 @@ public final class MainFrame extends javax.swing.JFrame {
     private javax.swing.JCheckBoxMenuItem writeSyncCheckBoxMenuItem;
     // End of variables declaration//GEN-END:variables
 
-    public void setLocation(String path ) {
+    public void setLocation(String path) {
         locationText.setText(path);
     }
     
     public void msg(String message) {
-        msgTextArea.append(message+'\n');
+        msgTextArea.append(message + '\n');
     }
-  
+    
     public void applyTestParams() {
         if (Gui.controlPanel != null) {
             Gui.controlPanel.applySettings();

--- a/jdm-core/src/main/java/jdiskmark/SharingPanel.java
+++ b/jdm-core/src/main/java/jdiskmark/SharingPanel.java
@@ -1,0 +1,211 @@
+package jdiskmark;
+
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import java.awt.*;
+
+/**
+ * Sharing tab panel (issue #117).
+ *
+ * Layout:
+ *
+ *  ┌──────────────────────────┬───────────────────────────────────────────────────────────────────────┐
+ *  │ ☑ Share benchmark        │ Endpoint — https://test.jdiskmark.net:5000/api/benchmarks/upload      │
+ *  │   results with the       │  ○ Production  ○ Test (test.jdiskmark.net)  ○ Localhost               │
+ *  │   JDiskMark community    │  Protocol:  ○ HTTPS  ○ HTTP                                           │
+ *  │   portal                 │                                                                       │
+ *  │                          │                                                                       │
+ *  │   ● Enabled              │                                                                       │
+ *  └──────────────────────────┴───────────────────────────────────────────────────────────────────────┘
+ *
+ * Radios are laid out horizontally to keep the vertical footprint minimal — no
+ * scroll bar is triggered at the default window height.
+ *
+ * The titled border on the right panel doubles as a URL preview; it is updated
+ * live whenever the endpoint or protocol changes.
+ *
+ * Developer controls (endpoint / protocol) will be hidden in a future
+ * production build; they remain here for testing.
+ */
+public class SharingPanel extends JPanel {
+
+    // ── Controls ──────────────────────────────────────────────────────────────
+    private final JCheckBox  enableCheckBox;
+    private final JLabel     statusLabel;
+
+    private final JRadioButton localRb;
+    private final JRadioButton testRb;
+    private final JRadioButton prodRb;
+
+    private final JRadioButton httpRb;
+    private final JRadioButton httpsRb;
+
+    /** The right dev-controls panel whose titled border shows the live URL. */
+    private final JPanel devPanel;
+
+
+    public SharingPanel() {
+        setLayout(new BorderLayout());
+
+        // ── Outer split: left (toggle) | right (dev controls) ─────────────────
+        JPanel grid = new JPanel(new GridBagLayout());
+        grid.setBorder(BorderFactory.createEmptyBorder(8, 6, 8, 6));
+
+        // ── LEFT ──────────────────────────────────────────────────────────────
+        JPanel leftPanel = new JPanel(new GridBagLayout());
+        leftPanel.setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 8));
+
+        enableCheckBox = new JCheckBox(
+                "<html><b>Share benchmark results with<br>the JDiskMark community portal</b></html>");
+
+        statusLabel = new JLabel("○ Disabled");
+        statusLabel.setFont(statusLabel.getFont().deriveFont(Font.PLAIN, 11f));
+        statusLabel.setForeground(Color.GRAY);
+
+        GridBagConstraints lc = new GridBagConstraints();
+        lc.gridx = 0; lc.fill = GridBagConstraints.HORIZONTAL; lc.weightx = 1;
+        lc.anchor = GridBagConstraints.NORTHWEST; lc.insets = new Insets(0, 0, 4, 0);
+
+        lc.gridy = 0; leftPanel.add(enableCheckBox, lc);
+        lc.gridy = 1; lc.insets = new Insets(0, 4, 0, 0);
+        leftPanel.add(statusLabel, lc);
+        lc.gridy = 2; lc.weighty = 1; lc.fill = GridBagConstraints.BOTH;
+        leftPanel.add(Box.createVerticalGlue(), lc);
+
+        // ── RIGHT: developer controls ─────────────────────────────────────────
+        // Endpoint radios
+        ButtonGroup endpointGroup = new ButtonGroup();
+        prodRb  = new JRadioButton("Production (www.jdiskmark.net)");
+        testRb  = new JRadioButton("Test (test.jdiskmark.net)");
+        localRb = new JRadioButton("Localhost");
+        endpointGroup.add(prodRb);
+        endpointGroup.add(testRb);
+        endpointGroup.add(localRb);
+
+        // Protocol radios
+        ButtonGroup protocolGroup = new ButtonGroup();
+        httpsRb = new JRadioButton("HTTPS");
+        httpRb  = new JRadioButton("HTTP");
+        protocolGroup.add(httpsRb);
+        protocolGroup.add(httpRb);
+
+        // Endpoint row
+        JPanel endpointRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 2));
+        endpointRow.add(prodRb);
+        endpointRow.add(testRb);
+        endpointRow.add(localRb);
+
+        // Protocol row
+        JPanel protocolRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 2));
+        protocolRow.add(new JLabel("Protocol:"));
+        protocolRow.add(httpsRb);
+        protocolRow.add(httpRb);
+
+        // Assemble with GridBagLayout so rows stretch horizontally
+        devPanel = new JPanel(new GridBagLayout());
+        // border title is set in refreshBorderTitle()
+        GridBagConstraints dc = new GridBagConstraints();
+        dc.gridx = 0; dc.fill = GridBagConstraints.HORIZONTAL; dc.weightx = 1;
+        dc.anchor = GridBagConstraints.NORTHWEST; dc.insets = new Insets(0, 0, 2, 0);
+
+        dc.gridy = 0; devPanel.add(endpointRow, dc);
+        dc.gridy = 1; devPanel.add(protocolRow, dc);
+        dc.gridy = 2; dc.weighty = 1; dc.fill = GridBagConstraints.BOTH;
+        devPanel.add(Box.createVerticalGlue(), dc);
+
+        // ── Outer grid assembly ────────────────────────────────────────────────
+        GridBagConstraints oc = new GridBagConstraints();
+        oc.gridy = 0; oc.fill = GridBagConstraints.BOTH; oc.weighty = 1;
+        oc.anchor = GridBagConstraints.NORTHWEST;
+
+        oc.gridx = 0; oc.weightx = 0.35; oc.insets = new Insets(0, 0, 0, 4);
+        grid.add(leftPanel, oc);
+
+        oc.gridx = 1; oc.weightx = 0.65; oc.insets = new Insets(0, 0, 0, 0);
+        grid.add(devPanel, oc);
+
+        // ── Scroll pane: vertical only ─────────────────────────────────────────
+        JPanel northWrapper = new JPanel(new BorderLayout());
+        northWrapper.add(grid, BorderLayout.NORTH);
+
+        JScrollPane scrollPane = new JScrollPane(northWrapper,
+                JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+                JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        scrollPane.setBorder(BorderFactory.createEmptyBorder());
+        add(scrollPane, BorderLayout.CENTER);
+
+        // ── Listeners ──────────────────────────────────────────────────────────
+        enableCheckBox.addActionListener(e -> onToggleSharing());
+        prodRb .addActionListener(e -> onEndpointChanged(Portal.PRODUCTION_UPLOAD_LOCATOR));
+        testRb .addActionListener(e -> onEndpointChanged(Portal.TEST_UPLOAD_LOCATOR));
+        localRb.addActionListener(e -> onEndpointChanged(Portal.LOCAL_UPLOAD_LOCATOR));
+        httpsRb.addActionListener(e -> onProtocolChanged(Portal.HTTPS));
+        httpRb .addActionListener(e -> onProtocolChanged(Portal.HTTP));
+
+        refresh();
+    }
+
+    // ── Event handlers ─────────────────────────────────────────────────────────
+
+    private void onToggleSharing() {
+        App.sharePortal = enableCheckBox.isSelected();
+        App.saveConfig();
+        App.msg(App.sharePortal ? "Portal upload enabled." : "Portal upload disabled.");
+        refresh();
+    }
+
+    private void onEndpointChanged(String locator) {
+        Portal.uploadResourceLocator = locator;
+        App.saveConfig();
+        refreshBorderTitle();
+    }
+
+    private void onProtocolChanged(String protocol) {
+        Portal.uploadProtocol = protocol;
+        App.saveConfig();
+        refreshBorderTitle();
+    }
+
+    // ── Sync ───────────────────────────────────────────────────────────────────
+
+    /** Synchronises all controls to the current {@link App} / {@link Portal} state. */
+    public void refresh() {
+        enableCheckBox.setSelected(App.sharePortal);
+
+        if (App.sharePortal) {
+            statusLabel.setText("● Enabled");
+            statusLabel.setForeground(new Color(0, 150, 60));
+        } else {
+            statusLabel.setText("○ Disabled");
+            statusLabel.setForeground(Color.GRAY);
+        }
+
+        // Endpoint
+        if (Portal.uploadResourceLocator.equalsIgnoreCase(Portal.LOCAL_UPLOAD_LOCATOR)) {
+            localRb.setSelected(true);
+        } else if (Portal.uploadResourceLocator.equalsIgnoreCase(Portal.TEST_UPLOAD_LOCATOR)) {
+            testRb.setSelected(true);
+        } else {
+            prodRb.setSelected(true);
+        }
+
+        // Protocol
+        if (Portal.uploadProtocol.equalsIgnoreCase(Portal.HTTPS)) {
+            httpsRb.setSelected(true);
+        } else {
+            httpRb.setSelected(true);
+        }
+
+        refreshBorderTitle();
+    }
+
+    /**
+     * Updates the titled border of the developer panel to reflect the currently
+     * constructed upload URL.  Called whenever endpoint or protocol changes.
+     */
+    private void refreshBorderTitle() {
+        String title = "Endpoint \u2014 " + Portal.getUploadUrl();
+        devPanel.setBorder(BorderFactory.createTitledBorder(title));
+        devPanel.repaint();
+    }
+}

--- a/jdm-core/src/main/java/jdiskmark/SharingPanel.java
+++ b/jdm-core/src/main/java/jdiskmark/SharingPanel.java
@@ -1,7 +1,6 @@
 package jdiskmark;
 
 import javax.swing.*;
-import javax.swing.border.TitledBorder;
 import java.awt.*;
 
 /**

--- a/jdm-core/src/main/java/jdiskmark/UtilOs.java
+++ b/jdm-core/src/main/java/jdiskmark/UtilOs.java
@@ -869,4 +869,126 @@ public class UtilOs {
 
         return ""; // Return an empty string if no processor name was found
     }
-}
+
+    // ─── System ID ────────────────────────────────────────────────────────────
+
+    /**
+     * Returns a stable, non-PII system identifier suitable for anonymous
+     * benchmark attribution.
+     *
+     * <p>Strategy (first successful source wins):
+     * <ol>
+     *   <li>Windows &mdash; {@code MachineGuid} from the Cryptography registry key
+     *       (readable without admin)</li>
+     *   <li>Linux   &mdash; {@code /etc/machine-id} (world-readable)</li>
+     *   <li>macOS   &mdash; {@code IOPlatformUUID} via {@code ioreg} (no admin)</li>
+     *   <li>Fallback &mdash; the previously persisted {@code systemId} from
+     *       {@code jdm.properties}, or a freshly generated {@link java.util.UUID}</li>
+     * </ol>
+     *
+     * <p>The raw OS value is SHA-256 hashed and the first 32 hex characters are
+     * returned, so the original system identifier is never stored or transmitted.
+     *
+     * @param osName      the value of {@code System.getProperty("os.name")}
+     * @param persistedId the value already stored in {@code jdm.properties}
+     *                    (may be {@code null} or blank on first run)
+     * @return a 32-character lowercase hex string identifying this system
+     */
+    public static String getMachineSystemId(String osName, String persistedId) {
+        String raw = null;
+        try {
+            if (isWindows(osName)) {
+                raw = readWindowsMachineGuid();
+            } else if (isLinux(osName)) {
+                raw = readLinuxMachineId();
+            } else if (isMacOs(osName)) {
+                raw = readMacOsPlatformUuid();
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "getMachineSystemId: OS source failed, using fallback", e);
+        }
+
+        if (raw != null && !raw.isBlank()) {
+            return sha256Hex32(raw);
+        }
+
+        // Fallback: reuse persisted id (survives across sessions) or generate once.
+        if (persistedId != null && !persistedId.isBlank()) {
+            return persistedId;
+        }
+        LOGGER.warning("getMachineSystemId: all sources failed, generating a random id");
+        return java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 32);
+    }
+
+    /** Reads HKLM\SOFTWARE\Microsoft\Cryptography\MachineGuid (no admin required). */
+    private static String readWindowsMachineGuid() throws IOException, InterruptedException {
+        Process p = new ProcessBuilder(
+                "reg", "query",
+                "HKLM\\SOFTWARE\\Microsoft\\Cryptography",
+                "/v", "MachineGuid")
+                .redirectErrorStream(true)
+                .start();
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.contains("MachineGuid")) {
+                    String[] parts = line.trim().split("\\s+");
+                    if (parts.length >= 3) {
+                        return parts[parts.length - 1].trim();
+                    }
+                }
+            }
+        }
+        p.waitFor();
+        return null;
+    }
+
+    /** Reads /etc/machine-id (world-readable on all mainstream Linux distros). */
+    private static String readLinuxMachineId() throws IOException {
+        java.nio.file.Path mid = java.nio.file.Paths.get("/etc/machine-id");
+        if (java.nio.file.Files.exists(mid)) {
+            return java.nio.file.Files.readString(mid).trim();
+        }
+        java.nio.file.Path dbus = java.nio.file.Paths.get("/var/lib/dbus/machine-id");
+        if (java.nio.file.Files.exists(dbus)) {
+            return java.nio.file.Files.readString(dbus).trim();
+        }
+        return null;
+    }
+
+    /** Reads IOPlatformUUID via ioreg (no admin required on macOS). */
+    private static String readMacOsPlatformUuid() throws IOException, InterruptedException {
+        Process p = new ProcessBuilder(
+                "ioreg", "-rd1", "-c", "IOPlatformExpertDevice")
+                .redirectErrorStream(true)
+                .start();
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.contains("IOPlatformUUID")) {
+                    int eq = line.indexOf('=');
+                    if (eq >= 0) {
+                        return line.substring(eq + 1).trim().replace("\"", "");
+                    }
+                }
+            }
+        }
+        p.waitFor();
+        return null;
+    }
+
+    /** Returns the first 32 hex characters of the SHA-256 hash of {@code input}. */
+    private static String sha256Hex32(String input) {
+        try {
+            java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(input.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(64);
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.substring(0, 32);
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new RuntimeException(e); // SHA-256 is mandatory in every JVM
+        }
+    }
+}

--- a/jdm-core/src/test/java/jdiskmark/AppTest.java
+++ b/jdm-core/src/test/java/jdiskmark/AppTest.java
@@ -27,6 +27,16 @@ class AppTest {
     }
 
     /**
+     * The first-run consent flag must default to false so that a brand-new
+     * installation always presents the portal-upload consent dialog (issue #117).
+     */
+    @Test
+    void portalConsentAsked_onStartup_isFalse() {
+        assertFalse(App.portalConsentAsked,
+                "portalConsentAsked must default to false so first-run consent dialog is shown on a new install");
+    }
+
+    /**
      * Every AppIcon enum entry must resolve to an actual classpath resource.
      * This guards against icon renames or path typos that would cause the
      * About dialog (and taskbar/title-bar) to silently display no icon.


### PR DESCRIPTION
summary of changes:
1. moved sharing controls to dedicated sharing tab, no longer password locked
    
    <img width="749" height="122" alt="image" src="https://github.com/user-attachments/assets/ba96fb17-54c9-46d1-9749-d67c39ae4c16" />

2. one time prompt on a version's install (if we want to not prompt per version) we can store the designation in a more permanent location of cross version config file... let me know what you guys think!!!
    
    <img width="567" height="209" alt="Image" src="https://github.com/user-attachments/assets/b8d0ddee-cc03-422d-82e2-0a0b105e5f7c" />
3. about dialog has link to our website
    
    <img width="481" height="218" alt="Image" src="https://github.com/user-attachments/assets/39aa03b4-21de-4bc1-8988-34c6a61411b2" />
4. systemId replacing user name to avoid collecting PII before the user has authenticated
    - allows users to later link their anonymous uploads to their profiles if they authenticate
    - allows to a way to combat abuse against a system if submitted anonymously (its spoof able, so we should not publish this info)