### PR TITLE
#179 #182 production prep, jfreechart wrapup

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -30,6 +30,27 @@ The default position is: **do nothing with git unless explicitly told to.**
 
 ---
 
+### Design Documentation
+
+The `jdm-core/docs/` folder contains authoritative design documents:
+
+| File | Covers |
+|---|---|
+| [`design.md`](jdm-core/docs/design.md) | GUI layout decisions, active design trades, package organisation |
+| [`theme.md`](jdm-core/docs/theme.md) | Theme and palette architecture, unlinked palette constraints, per-theme colour reference |
+
+- **Read before coding.** Before making any change to theming, chart palettes,
+  LAF configuration, or UI layout, read the relevant doc(s) in `jdm-core/docs/`.
+  This prevents violating established constraints (e.g. unlinked palettes must
+  not override LAF-owned chrome — see `theme.md`).
+
+- **Update after coding.** If a code change affects something documented in
+  `jdm-core/docs/` — a new palette, a renamed constant, a changed architecture
+  decision, a new design constraint — update the relevant doc in the same session.
+  Do not leave docs stale.
+
+---
+
 ### Coding Practices & Conventions
 
 - **No unrequested features.** Implement only what is asked.
@@ -45,6 +66,9 @@ The default position is: **do nothing with git unless explicitly told to.**
 - **Issue references:** Use `#N` to reference GitHub issue numbers in commits.
 - **IDE:** NetBeans is the primary IDE. Do not reformat or reorganize files in
   ways that would conflict with NetBeans project settings.
+- **Keep design docs current.** When a code change touches an area covered by
+  `jdm-core/docs/`, update the relevant doc in the same session — do not leave
+  design documentation out of sync with the code.
 
 ---
 

--- a/jdm-core/docs/theme.md
+++ b/jdm-core/docs/theme.md
@@ -59,13 +59,60 @@ Theme enum
 
 **`Palette`** drives **Graph > Color Palette** menu (via `GraphPaletteMenu` iterating `values()`):
 
-    CLASSIC, LAGOON, MARINE, EMBER, BETA
+    BETA_DARK, BETA_LIGHT, LAGOON, MARINE, EMBER, CLASSIC
 
 **`Theme`** drives **Graph > Window Theme** menu (via `GraphThemeMenu` iterating `values()`):
 
     DARK, LIGHT, DARCULA, OLD_GLORY, SAKURA, HARVEST
 
 ---
+
+## Unlinked Palette Design Constraint
+
+**Unlinked palettes** (every `Palette` constant that is *not* returned by
+`Theme.hasLinkedPalette()`) may only set colors and strokes **inside the graph
+canvas**.  The surrounding UI chrome — axis labels, chart title, legend
+background and border, outer chart background — is owned by the active LAF and
+must not be overridden.
+
+### What an unlinked palette MAY override
+
+| `PaletteDefinition` method | Scope |
+|---|---|
+| `plotBackground()` | Fill color of the XY plot canvas (inside the axes) |
+| `plotOutline()` | Border of the plot canvas |
+| `gridColor()` | Domain and range gridlines |
+| `bwWrite*()` / `bwRead*()` | Bandwidth renderer series paints (8 series) |
+| `msWriteLatency()` / `msReadLatency()` | Latency renderer series paints |
+| `bwWriteSampleStroke()` etc. | Per-series `BasicStroke` overrides |
+
+### What an unlinked palette MUST NOT override
+
+| `PaletteDefinition` method | Why |
+|---|---|
+| `chartBackground()` | Outer chart paint — set by LAF |
+| `textPaint()` | Axis labels, chart title, legend item text — set by LAF |
+| `legendBackground()` | Legend fill — set by LAF |
+| `legendBorderColor()` | Legend border — set by LAF |
+
+### Why this matters
+
+Unlinked palettes are LAF-agnostic and can be applied to any window theme
+(Dark, Light, Darcula, etc.).  Overriding text or legend colors forces values
+that may be unreadable on the current LAF — for example, forcing dark text
+while the Dark LAF renders a dark background.
+
+Linked palettes (Old Glory, Sakura, Harvest) are exempt because they are
+always applied together with a specific LAF that they control end-to-end.
+
+### Adding a new unlinked palette — checklist
+
+1. Create a class in `org.metricus.jdm.ui.palette` implementing `PaletteDefinition`.
+2. Only override the **MAY** methods listed above.
+3. Do **not** override `chartBackground()`, `textPaint()`, `legendBackground()`,
+   or `legendBorderColor()`.
+4. Add one line to the `Palette` enum (declaration order = menu order).
+5. No changes to `Gui.java`, `GraphPaletteMenu`, or any theme class are needed.
 
 ## Adding a New Theme — Checklist
 
@@ -279,9 +326,10 @@ These themes use their FlatLaf defaults without custom extras or UIManager overr
 
 | Theme | Class | LAF Class |
 |---|---|---|
-| Dark | [`DarkTheme.java`](file:///c:/Users/james/git/jdm-java/jdm-core/src/main/java/org/metricus/jdm/ui/theme/DarkTheme.java) | `FlatDarkLaf` / `FlatMacDarkLaf` |
-| Light | [`LightTheme.java`](file:///c:/Users/james/git/jdm-java/jdm-core/src/main/java/org/metricus/jdm/ui/theme/LightTheme.java) | `FlatLightLaf` / `FlatMacLightLaf` |
-| Darcula | [`DarculaTheme.java`](file:///c:/Users/james/git/jdm-java/jdm-core/src/main/java/org/metricus/jdm/ui/theme/DarculaTheme.java) | `FlatDarculaLaf` |
+| Dark | [`DarkTheme.java`](../src/main/java/org/metricus/jdm/ui/theme/DarkTheme.java) | `FlatDarkLaf` / `FlatMacDarkLaf` |
+| Light | [`LightTheme.java`](../src/main/java/org/metricus/jdm/ui/theme/LightTheme.java) | `FlatLightLaf` / `FlatMacLightLaf` |
+| Darcula | [`DarculaTheme.java`](../src/main/java/org/metricus/jdm/ui/theme/DarculaTheme.java) | `FlatDarculaLaf` |
+| Harvest | [`HarvestTheme.java`](../src/main/java/org/metricus/jdm/ui/theme/HarvestTheme.java) | `FlatDarkLaf` with autumn overrides — linked palette |
 
 Badge colors follow the same `ThemeDefinition` interface but with simpler values:
 
@@ -303,7 +351,10 @@ and resets `FlatLaf.setGlobalExtraDefaults(null)` so previous theme colors don't
 
 ### restoreDefaultPlotBackground()
 
-Called by Classic, Blue-Green, Bard Cool/Warm. Not called by Beta, Old Glory, or Sakura.
+Called at the start of every `Palette.apply(PaletteDefinition)` invocation to
+reset any previously applied custom canvas colors and strokes before the new
+palette's values are written.  Palette implementations that supply their own
+`plotBackground()` will immediately overwrite this reset.
 
 ```
 plot.setBackgroundPaint(Color.DARK_GRAY.darker())

--- a/jdm-core/src/main/java/jdiskmark/App.java
+++ b/jdm-core/src/main/java/jdiskmark/App.java
@@ -630,6 +630,7 @@ public class App {
             case "BLUE_GREEN" -> "LAGOON";
             case "BARD_COOL"  -> "MARINE";
             case "BARD_WARM"  -> "EMBER";
+            case "BETA"       -> "BETA_DARK";
             default -> value;
         };
         try {

--- a/jdm-core/src/main/java/jdiskmark/BenchmarkWorker.java
+++ b/jdm-core/src/main/java/jdiskmark/BenchmarkWorker.java
@@ -114,6 +114,7 @@ public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
             Gui.resetBenchmarkData();
             Gui.updateLegendAndAxis();
         }
+        Gui.lockSampleAxis(App.numOfSamples);
 
         BenchmarkRunner bRunner = new BenchmarkRunner(listener, App.getConfig());
         Benchmark benchmark = bRunner.execute();
@@ -186,6 +187,7 @@ public class BenchmarkWorker extends SwingWorker<Benchmark, Sample> {
         if (App.autoRemoveData) {
             Util.deleteDirectory(dataDir);
         }
+        Gui.unlockSampleAxis();
         App.state = App.State.IDLE_STATE;
         Gui.mainFrame.adjustSensitivity();
     }

--- a/jdm-core/src/main/java/jdiskmark/DrivePanel.java
+++ b/jdm-core/src/main/java/jdiskmark/DrivePanel.java
@@ -58,7 +58,9 @@ public class DrivePanel extends JPanel {
 
     private static class DriveEntry {
         final File   root;
-        final String label;
+        final String pathLabel;    // "/ [SSD]"
+        final String capacity;     // "467 GB"
+        String       model = "loading\u2026";   // filled in asynchronously
 
         DriveEntry(File root) {
             this.root = root;
@@ -66,11 +68,14 @@ public class DrivePanel extends JPanel {
             String typeDesc = Util.getDriveType(root);
             String type     = (typeDesc != null && !typeDesc.isBlank())
                               ? "  [" + typeDesc + "]" : "";
-            label = root.getAbsolutePath() + type + "   —   "
-                    + String.format("%.0f GB", totalGb);
+            pathLabel = root.getAbsolutePath() + type;
+            capacity  = String.format("%.0f GB", totalGb);
         }
 
-        @Override public String toString() { return label; }
+        @Override public String toString() {
+            // path   —   model   —   capacity
+            return pathLabel + "   \u2014   " + model + "   \u2014   " + capacity;
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -331,7 +336,25 @@ public class DrivePanel extends JPanel {
             driveCombo.removeAllItems();
             for (File root : File.listRoots()) {
                 if (root.getTotalSpace() == 0) continue;
-                driveCombo.addItem(new DriveEntry(root));
+                DriveEntry entry = new DriveEntry(root);
+                driveCombo.addItem(entry);
+                // Fetch the drive model in the background, then refresh the combo
+                new SwingWorker<String, Void>() {
+                    @Override
+                    protected String doInBackground() {
+                        return Util.getDriveModel(root);
+                    }
+                    @Override
+                    protected void done() {
+                        try {
+                            String m = get();
+                            entry.model = (m != null && !m.isBlank()) ? m : "\u2014";
+                        } catch (Exception ex) {
+                            entry.model = "\u2014";
+                        }
+                        driveCombo.repaint();
+                    }
+                }.execute();
             }
         } finally {
             suppressComboEvents = false;

--- a/jdm-core/src/main/java/jdiskmark/Gui.java
+++ b/jdm-core/src/main/java/jdiskmark/Gui.java
@@ -1062,6 +1062,15 @@ public final class Gui {
         controlPanel.refreshReadMetrics();
         controlPanel.refreshWriteMetrics();
     }
+
+    public static void lockSampleAxis(int numSamples) {
+        sampleAxis.setAutoRange(false);
+        sampleAxis.setRange(1, numSamples);
+    }
+
+    public static void unlockSampleAxis() {
+        sampleAxis.setAutoRange(true);
+    }
     
     public static void updateLegendAndAxis() {
         bwRenderer.setSeriesVisibleInLegend(0, App.hasWriteOperation());

--- a/jdm-core/src/main/java/jdiskmark/Gui.java
+++ b/jdm-core/src/main/java/jdiskmark/Gui.java
@@ -65,7 +65,7 @@ public final class Gui {
     
     // display settings
     public static Theme theme = Theme.DARK;
-    public static Palette palette = Palette.BETA;
+    public static Palette palette = Palette.BETA_DARK;
     public static boolean showBadges = true;
     public static boolean showMaxMin = false;
     public static boolean showDriveAccess = true;

--- a/jdm-core/src/main/java/jdiskmark/Gui.java
+++ b/jdm-core/src/main/java/jdiskmark/Gui.java
@@ -256,10 +256,13 @@ public final class Gui {
         UIManager.put("TabbedPane.inactiveUnderlineColor", null);
         UIManager.put("TabbedPane.focusColor",             null);
         UIManager.put("TabbedPane.hoverColor",             null);
+        UIManager.put("TabbedPane.hoverForeground",        null);
         UIManager.put("ScrollBar.thumb",            null);
         UIManager.put("ScrollBar.thumbHover",       null);
         UIManager.put("ScrollBar.thumbPressed",     null);
         UIManager.put("TitlePane.foreground",       null);
+        UIManager.put("Button.default.background",  null);
+        UIManager.put("Button.default.foreground",  null);
     }
 
     /**
@@ -1523,6 +1526,11 @@ public final class Gui {
     }
 
     public static void browseLocation() {
+        if (selFrame != null && selFrame.isShowing()) {
+            selFrame.toFront();
+            selFrame.requestFocus();
+            return;
+        }
         selFrame = new SelectDriveFrame();
         if (App.locationDir != null && App.locationDir.exists()) {
             selFrame.setInitDir(App.locationDir);

--- a/jdm-core/src/main/java/jdiskmark/Gui.java
+++ b/jdm-core/src/main/java/jdiskmark/Gui.java
@@ -1064,8 +1064,9 @@ public final class Gui {
     }
 
     public static void lockSampleAxis(int numSamples) {
+        int start = App.nextSampleNumber;
         sampleAxis.setAutoRange(false);
-        sampleAxis.setRange(1, numSamples);
+        sampleAxis.setRange(start, start + numSamples - 1);
     }
 
     public static void unlockSampleAxis() {

--- a/jdm-core/src/main/java/jdiskmark/MainFrame.java
+++ b/jdm-core/src/main/java/jdiskmark/MainFrame.java
@@ -213,7 +213,9 @@ public final class MainFrame extends javax.swing.JFrame {
             public void componentShown(java.awt.event.ComponentEvent e) {
                 if (!heightAdjusted) {
                     heightAdjusted = true;
-                    setSize(getWidth(), getHeight() + 30);
+                    String os = System.getProperty("os.name", "").toLowerCase();
+                    int w = (os.contains("linux") || os.contains("mac")) ? Math.max(994, getWidth()) : getWidth();
+                    setSize(w, getHeight() + 30);
                 }
             }
         });

--- a/jdm-core/src/main/java/jdiskmark/MainFrame.java
+++ b/jdm-core/src/main/java/jdiskmark/MainFrame.java
@@ -13,7 +13,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.text.DefaultCaret;
 import jdiskmark.Exporter.ExportFormat;
-import org.metricus.jdm.ui.AppIcon;
 import org.metricus.jdm.ui.GraphPaletteMenu;
 import org.metricus.jdm.ui.GraphThemeMenu;
 import org.metricus.jdm.ui.Theme;
@@ -913,6 +912,7 @@ public final class MainFrame extends javax.swing.JFrame {
     private void showMaxMinCheckBoxMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_showMaxMinCheckBoxMenuItemActionPerformed
         Gui.showMaxMin = showMaxMinCheckBoxMenuItem.getState();
         App.saveConfig();
+        Gui.singleOpTrigReloadGraph();
     }//GEN-LAST:event_showMaxMinCheckBoxMenuItemActionPerformed
 
     private void writeSyncCheckBoxMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_writeSyncCheckBoxMenuItemActionPerformed
@@ -937,6 +937,7 @@ public final class MainFrame extends javax.swing.JFrame {
     private void showAccessCheckBoxMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_showAccessCheckBoxMenuItemActionPerformed
         Gui.showDriveAccess = showAccessCheckBoxMenuItem.getState();
         App.saveConfig();
+        Gui.singleOpTrigReloadGraph();
     }//GEN-LAST:event_showAccessCheckBoxMenuItemActionPerformed
 
     private void deleteSelBenchmarksItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_deleteSelBenchmarksItemActionPerformed

--- a/jdm-core/src/main/java/org/metricus/jdm/ui/Palette.java
+++ b/jdm-core/src/main/java/org/metricus/jdm/ui/Palette.java
@@ -5,6 +5,7 @@ import jdiskmark.Gui;
 import org.jfree.chart.block.BlockBorder;
 import org.jfree.chart.labels.StandardXYToolTipGenerator;
 import org.jfree.chart.plot.XYPlot;
+import org.metricus.jdm.ui.palette.BetaLightPalette;
 import org.metricus.jdm.ui.palette.BetaPalette;
 import org.metricus.jdm.ui.palette.ClassicPalette;
 import org.metricus.jdm.ui.palette.EmberPalette;
@@ -21,11 +22,12 @@ import org.metricus.jdm.ui.palette.MarinePalette;
  * menu automatically.
  */
 public enum Palette {
-    CLASSIC("Classic",  new ClassicPalette()),
-    LAGOON("Lagoon",    new LagoonPalette()),
-    MARINE("Marine",    new MarinePalette()),
-    EMBER("Ember",      new EmberPalette()),
-    BETA("Beta",        new BetaPalette());
+    BETA_DARK("Beta Dark",   new BetaPalette()),
+    BETA_LIGHT("Beta Light",  new BetaLightPalette()),
+    LAGOON("Lagoon",          new LagoonPalette()),
+    MARINE("Marine",          new MarinePalette()),
+    EMBER("Ember",            new EmberPalette()),
+    CLASSIC("Classic",        new ClassicPalette());
 
     private final String displayName;
     private final PaletteDefinition definition;

--- a/jdm-core/src/main/java/org/metricus/jdm/ui/palette/BetaLightPalette.java
+++ b/jdm-core/src/main/java/org/metricus/jdm/ui/palette/BetaLightPalette.java
@@ -1,0 +1,32 @@
+package org.metricus.jdm.ui.palette;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Stroke;
+import org.metricus.jdm.ui.PaletteDefinition;
+
+public final class BetaLightPalette implements PaletteDefinition {
+
+    private static final Stroke AVG_DASH = new BasicStroke(
+            1.8f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND,
+            10.0f, new float[]{6.0f, 6.0f}, 0.0f);
+
+    @Override public Color plotBackground() { return new Color(0xF5F5F0); }
+    @Override public Color plotOutline()     { return new Color(0xBBBBBB); }
+    @Override public Color gridColor()       { return new Color(0xD8D8D0); }
+
+    @Override public Color bwWriteSample()  { return new Color(0xE86000); }
+    @Override public Color bwWriteTrend()   { return new Color(0xE8, 0x60, 0x00, 200); }
+    @Override public Color bwWriteMax()     { return new Color(0xD4860A); }
+    @Override public Color bwWriteMin()     { return new Color(0x9E3A18); }
+    @Override public Color bwReadSample()   { return new Color(0x0277BD); }
+    @Override public Color bwReadTrend()    { return new Color(0x02, 0x77, 0xBD, 200); }
+    @Override public Color bwReadMax()      { return new Color(0x0288D1); }
+    @Override public Color bwReadMin()      { return new Color(0x01579B); }
+    @Override public Color msWriteLatency() { return new Color(0xE86000); }
+    @Override public Color msReadLatency()  { return new Color(0x0277BD); }
+
+
+    @Override public Stroke bwWriteTrendStroke() { return AVG_DASH; }
+    @Override public Stroke bwReadTrendStroke()  { return AVG_DASH; }
+}

--- a/jdm-core/src/main/java/org/metricus/jdm/ui/palette/BetaPalette.java
+++ b/jdm-core/src/main/java/org/metricus/jdm/ui/palette/BetaPalette.java
@@ -15,15 +15,15 @@ public final class BetaPalette implements PaletteDefinition {
     @Override public Color plotOutline()     { return new Color(0x555555); }
     @Override public Color gridColor()       { return new Color(0x3A3A3A); }
 
-    @Override public Color bwWriteSample()  { return new Color(0xE07B39); }
-    @Override public Color bwWriteTrend()   { return new Color(189, 176, 138, 200); }
+    @Override public Color bwWriteSample()  { return new Color(0xF56A00); }
+    @Override public Color bwWriteTrend()   { return new Color(0xF5, 0x6A, 0x00, 200); }
     @Override public Color bwWriteMax()     { return new Color(0xF5A623); }
     @Override public Color bwWriteMin()     { return new Color(0xC0623A); }
     @Override public Color bwReadSample()   { return new Color(0x4FC3F7); }
-    @Override public Color bwReadTrend()    { return new Color(160, 216, 239, 200); }
+    @Override public Color bwReadTrend()    { return new Color(0x4F, 0xC3, 0xF7, 200); }
     @Override public Color bwReadMax()      { return new Color(0x81D4FA); }
     @Override public Color bwReadMin()      { return new Color(0x0288D1); }
-    @Override public Color msWriteLatency() { return new Color(0xE07B39); }
+    @Override public Color msWriteLatency() { return new Color(0xF56A00); }
     @Override public Color msReadLatency()  { return new Color(0x4FC3F7); }
 
     @Override public Stroke bwWriteTrendStroke() { return AVG_DASH; }

--- a/jdm-core/src/main/java/org/metricus/jdm/ui/palette/BetaPalette.java
+++ b/jdm-core/src/main/java/org/metricus/jdm/ui/palette/BetaPalette.java
@@ -7,9 +7,9 @@ import org.metricus.jdm.ui.PaletteDefinition;
 
 public final class BetaPalette implements PaletteDefinition {
 
-    private static final Stroke AVG_DOT = new BasicStroke(
+    private static final Stroke AVG_DASH = new BasicStroke(
             1.8f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND,
-            10.0f, new float[]{2.0f, 6.0f}, 0.0f);
+            10.0f, new float[]{6.0f, 6.0f}, 0.0f);
 
     @Override public Color plotBackground() { return new Color(0x1C1C1C); }
     @Override public Color plotOutline()     { return new Color(0x555555); }
@@ -26,6 +26,6 @@ public final class BetaPalette implements PaletteDefinition {
     @Override public Color msWriteLatency() { return new Color(0xE07B39); }
     @Override public Color msReadLatency()  { return new Color(0x4FC3F7); }
 
-    @Override public Stroke bwWriteTrendStroke() { return AVG_DOT; }
-    @Override public Stroke bwReadTrendStroke()  { return AVG_DOT; }
+    @Override public Stroke bwWriteTrendStroke() { return AVG_DASH; }
+    @Override public Stroke bwReadTrendStroke()  { return AVG_DASH; }
 }

--- a/jdm-core/src/main/java/org/metricus/jdm/ui/theme/OldGloryTheme.java
+++ b/jdm-core/src/main/java/org/metricus/jdm/ui/theme/OldGloryTheme.java
@@ -70,9 +70,6 @@ public final class OldGloryTheme implements ThemeDefinition {
         m.put("ScrollBar.thumb",               uiColor(BLUE));
         m.put("ScrollBar.thumbHover",          uiColor(BLUE_HOVER));
         m.put("ScrollBar.thumbPressed",        uiColor(BLUE_PRESS));
-        // Default (accent-colored) buttons use a red background via @accentColor;
-        // force white text so it is readable against that red fill.
-        m.put("Button.default.foreground",     uiColor(Color.WHITE));
         return m;
     }
 

--- a/jdm-core/src/main/java/org/metricus/jdm/ui/theme/SakuraTheme.java
+++ b/jdm-core/src/main/java/org/metricus/jdm/ui/theme/SakuraTheme.java
@@ -33,7 +33,7 @@ public final class SakuraTheme implements ThemeDefinition {
     // DESIGN NOTES:
     // #FFFBFC: original pastel pink background
     // #FFF8FA: between FFBFC and FFF5F7
-    // #FFF5F7: partial setp up between FFBFC and FFF0F3
+    // #FFF5F7: partial step up between FFBFC and FFF0F3
     // #FFF0F3: Change from "#FFFBFC" to a slightly richer pastel pink
     // #FDE2E4: Slightly more muted, sophisticated pastel rose background
     // #FFE5EC: A bit deeper and warmer.

--- a/jdm-core/src/main/java/org/metricus/jdm/ui/theme/SakuraTheme.java
+++ b/jdm-core/src/main/java/org/metricus/jdm/ui/theme/SakuraTheme.java
@@ -30,6 +30,17 @@ public final class SakuraTheme implements ThemeDefinition {
     private static final String HEX_ROSE = "#D4607C";
     private static final String HEX_BARK = "#2D1B22";
 
+    // DESIGN NOTES:
+    // #FFFBFC: original pastel pink background
+    // #FFF8FA: between FFBFC and FFF5F7
+    // #FFF5F7: partial setp up between FFBFC and FFF0F3
+    // #FFF0F3: Change from "#FFFBFC" to a slightly richer pastel pink
+    // #FDE2E4: Slightly more muted, sophisticated pastel rose background
+    // #FFE5EC: A bit deeper and warmer.
+
+    private static final String HEX_BG   = "#FFFBFC";
+    static final Color BG = new Color(0xFFFBFC);
+
     private static javax.swing.plaf.ColorUIResource uiColor(Color c) {
         return new javax.swing.plaf.ColorUIResource(c);
     }
@@ -45,7 +56,7 @@ public final class SakuraTheme implements ThemeDefinition {
     public Map<String, String> flatLafExtras() {
         Map<String, String> extras = new LinkedHashMap<>();
         extras.put("@accentColor", HEX_ROSE);
-        extras.put("@background",  "#FFFBFC");
+        extras.put("@background",  HEX_BG);
         extras.put("@foreground",  HEX_BARK);
         extras.put("TitlePane.foreground", HEX_BARK);
         return extras;
@@ -116,11 +127,11 @@ public final class SakuraTheme implements ThemeDefinition {
                 1.2f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND,
                 10.0f, new float[]{2.0f, 6.0f}, 0.0f);
 
-        @Override public Color chartBackground()  { return Color.WHITE; }
+        @Override public Color chartBackground()  { return BG; }
         @Override public Color plotBackground()    { return Color.WHITE; }
         @Override public Color plotOutline()        { return new Color(0xCCCCCC); }
         @Override public Color gridColor()          { return new Color(0xEEEEEE); }
-        @Override public Color legendBackground()  { return Color.WHITE; }
+        @Override public Color legendBackground()  { return BG; }
         @Override public Color legendBorderColor() { return new Color(0xDDDDDD); }
 
         @Override public Color bwWriteSample()  { return PINK; }


### PR DESCRIPTION
summary of changes

#179 - jfreechart update wrapup
- remove workaround for dashes for legacy jfreechart
- lock chart size at start of benchmark
- beta light chart palette, update palette menu order

#182 - production prep
- notes on sakura theme bg colors, minor variable support to optimize maintenance if we change
- fix double location d click on graph
- fix styling on graph
- add drive model to drive select dropdown